### PR TITLE
feat: add filtered rom counts to list views

### DIFF
--- a/src/components/RomStats.vue
+++ b/src/components/RomStats.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="rom-stats">
+    <template v-if="isFiltered">
+      Showing {{ formattedCount }} of {{ formattedTotal }} {{ label }}
+      <span v-if="size" class="rom-stats__size">({{ formattedSize }})</span>
+    </template>
+    <template v-else>
+      {{ formattedTotal }} {{ label }}
+      <span v-if="size" class="rom-stats__size">({{ formattedSize }})</span>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { formatBytes, formatNumber } from '@/utils/number.utils';
+
+const props = withDefaults(
+  defineProps<{
+    total: number;
+    filtered?: number;
+    size?: number;
+    label?: string;
+  }>(),
+  {
+    label: 'ROMs',
+  }
+);
+
+const isFiltered = computed(() => props.filtered !== undefined && props.filtered !== props.total);
+
+const formattedCount = computed(() => formatNumber(props.filtered ?? 0));
+const formattedTotal = computed(() => formatNumber(props.total));
+const formattedSize = computed(() => formatBytes(props.size ?? 0));
+</script>
+
+<style lang="less" scoped>
+.rom-stats {
+  font-size: var(--font-size-sm);
+  padding: var(--space-4) var(--space-12);
+  padding-top: var(--space-2);
+
+  &__size {
+    color: var(--p-text-muted-color);
+  }
+}
+</style>

--- a/src/views/FavoritesView.vue
+++ b/src/views/FavoritesView.vue
@@ -1,14 +1,22 @@
 <template>
-  <RomListLayout mode="favorites">
-    <template #default="{ filteredRoms, loading }">
-      <RomList
-        class="library-view__content-list"
-        :loading="loading"
-        :roms="filteredRoms"
-        :rom-selections="romSelections"
-        :compact="false"
-        @rom-selected="romSelections = $event"
-      />
+  <RomListLayout class="favorites-view" mode="favorites">
+    <template #default="{ filteredRoms, totalRoms, filteredSize, loading }">
+      <div class="favorites-view__content">
+        <RomStats
+          :filtered="filteredRoms.length"
+          :total="totalRoms"
+          :size="filteredSize"
+          label="favorites"
+        />
+        <RomList
+          class="favorites-view__list"
+          :loading="loading"
+          :roms="filteredRoms"
+          :rom-selections="romSelections"
+          :compact="false"
+          @rom-selected="romSelections = $event"
+        />
+      </div>
     </template>
     <template #rom-details>
       <RomDetailView
@@ -32,6 +40,7 @@ import RomListLayout from '@/layouts/RomListLayout.vue';
 import RomDetailView from '@/views/RomDetailView.vue';
 import RomActionView from '@/views/RomActionView.vue';
 import RomList from '@/components/RomList.vue';
+import RomStats from '@/components/RomStats.vue';
 
 const romSelections = ref<string[]>([]);
 
@@ -42,4 +51,18 @@ function handleFavorite(favorite: boolean) {
 }
 </script>
 
-<style scoped lang="less"></style>
+<style lang="less" scoped>
+.favorites-view {
+  &__content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  &__list {
+    flex: 1;
+    min-height: 0;
+  }
+}
+</style>

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -1,10 +1,8 @@
 <template>
   <RomListLayout class="library-view" mode="all">
-    <template #default="{ filteredRoms, loading }">
+    <template #default="{ filteredRoms, totalRoms, filteredSize, loading }">
       <div class="library-view__content">
-        <div class="library-view__summary">
-          {{ librarySummary }}
-        </div>
+        <RomStats :filtered="filteredRoms.length" :total="totalRoms" :size="filteredSize" />
         <RomList
           class="library-view__list"
           :loading="loading"
@@ -31,25 +29,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
-import { useRomStore } from '@/stores';
+import { ref } from 'vue';
+
 import RomListLayout from '@/layouts/RomListLayout.vue';
 import RomDetailView from '@/views/RomDetailView.vue';
 import RomActionView from '@/views/RomActionView.vue';
 import RomList from '@/components/RomList.vue';
-import { formatBytes, formatNumber } from '@/utils/number.utils';
-import { pluralize } from '@/utils/string.utils';
+import RomStats from '@/components/RomStats.vue';
 
-const romStore = useRomStore();
 const romSelections = ref<string[]>([]);
-
-// TODO: Empty state: “Your ROM library is empty. Time to add some games!”
-const librarySummary = computed(() => {
-  const { totalSizeBytes, totalRoms, systemCounts } = romStore.stats;
-  const totalSystems = Object.keys(systemCounts).length;
-
-  return `You have a ${formatBytes(totalSizeBytes)} ROM library with ${formatNumber(totalRoms)} ${pluralize(totalRoms, 'ROM')} across ${formatNumber(totalSystems)} ${pluralize(totalSystems, 'system')}.`;
-});
 </script>
 
 <style lang="less" scoped>
@@ -59,13 +47,6 @@ const librarySummary = computed(() => {
     display: flex;
     flex-direction: column;
     min-height: 0; // allow the list to shrink inside flex parent
-  }
-
-  &__summary {
-    font-size: var(--font-size-sm);
-    color: var(--p-text-muted-color);
-    padding: var(--space-4) var(--space-10);
-    padding-top: var(--space-2);
   }
 
   &__list {

--- a/src/views/SystemView.vue
+++ b/src/views/SystemView.vue
@@ -1,14 +1,22 @@
 <template>
-  <RomListLayout :system="system" mode="system">
-    <template #default="{ filteredRoms, loading }">
-      <RomList
-        class="system-view__content-list"
-        :loading="loading"
-        :roms="filteredRoms"
-        :rom-selections="romSelections"
-        :compact="false"
-        @rom-selected="romSelections = $event"
-      />
+  <RomListLayout class="system-view" :system="system" mode="system">
+    <template #default="{ filteredRoms, totalRoms, filteredSize, loading }">
+      <div class="system-view__content">
+        <RomStats
+          :filtered="filteredRoms.length"
+          :total="totalRoms"
+          :size="filteredSize"
+          :label="statsLabel"
+        />
+        <RomList
+          class="system-view__list"
+          :loading="loading"
+          :roms="filteredRoms"
+          :rom-selections="romSelections"
+          :compact="false"
+          @rom-selected="romSelections = $event"
+        />
+      </div>
     </template>
     <template #rom-details>
       <RomDetailView
@@ -26,16 +34,33 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import RomListLayout from '@/layouts/RomListLayout.vue';
 import RomDetailView from '@/views/RomDetailView.vue';
 import RomActionView from '@/views/RomActionView.vue';
 import RomList from '@/components/RomList.vue';
+import RomStats from '@/components/RomStats.vue';
+import { getSystemDisplayName } from '@/utils/systems';
 
 import type { SystemCode } from '@/types/system';
 
-defineProps<{ system: SystemCode }>();
+const props = defineProps<{ system: SystemCode }>();
 const romSelections = ref<string[]>([]);
+const statsLabel = computed(() => `${getSystemDisplayName(props.system)} ROMs`);
 </script>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+.system-view {
+  &__content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  &__list {
+    flex: 1;
+    min-height: 0;
+  }
+}
+</style>

--- a/src/views/TagView.vue
+++ b/src/views/TagView.vue
@@ -1,14 +1,22 @@
 <template>
-  <RomListLayout :tag="tag" mode="tag">
-    <template #default="{ filteredRoms, loading }">
-      <RomList
-        class="library-view__content-list"
-        :loading="loading"
-        :roms="filteredRoms"
-        :rom-selections="romSelections"
-        :compact="false"
-        @rom-selected="romSelections = $event"
-      />
+  <RomListLayout class="tag-view" :tag="tag" mode="tag">
+    <template #default="{ filteredRoms, totalRoms, filteredSize, loading }">
+      <div class="tag-view__content">
+        <RomStats
+          :filtered="filteredRoms.length"
+          :total="totalRoms"
+          :size="filteredSize"
+          :label="statsLabel"
+        />
+        <RomList
+          class="tag-view__list"
+          :loading="loading"
+          :roms="filteredRoms"
+          :rom-selections="romSelections"
+          :compact="false"
+          @rom-selected="romSelections = $event"
+        />
+      </div>
     </template>
     <template #rom-details>
       <RomDetailView
@@ -26,16 +34,30 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, computed } from 'vue';
 import RomListLayout from '@/layouts/RomListLayout.vue';
 import RomDetailView from '@/views/RomDetailView.vue';
 import RomActionView from '@/views/RomActionView.vue';
 import RomList from '@/components/RomList.vue';
+import RomStats from '@/components/RomStats.vue';
 
-defineProps<{ tag: string }>();
-useRouter();
+const props = defineProps<{ tag: string }>();
 const romSelections = ref<string[]>([]);
+const statsLabel = computed(() => `ROMs tagged "${props.tag}"`);
 </script>
 
-<style scoped lang="less"></style>
+<style lang="less" scoped>
+.tag-view {
+  &__content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  &__list {
+    flex: 1;
+    min-height: 0;
+  }
+}
+</style>


### PR DESCRIPTION
ROM count and total size now shows on all rom list views including Favorites, Tag, and System views. When filtering or searching, the counts will update to "Showing X of Y ROMs" with the filtered size".
