### PR TITLE
fix: zip files now pass hash verification after syncing

### DIFF
--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -6,8 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import logger from 'electron-log/main';
 import * as schema from './schema';
-import { migrateLowdbToSqlite } from './migrate-from-lowdb';
-import { migrateRegionDetection } from './migrate-region-detection';
+import { runDataMigrations } from './migrations';
 
 const log = logger.scope('db');
 
@@ -86,11 +85,8 @@ export async function initializeDatabase() {
   log.info('Running database migrations...', migrationsPath);
   migrate(db, { migrationsFolder: migrationsPath });
 
-  // Migrate from LowDB if needed (existing users)
-  await migrateLowdbToSqlite(db, baseDir);
-
-  // Fix region detection false positives (issue #97)
-  await migrateRegionDetection(db, baseDir);
+  // Run data migrations (LowDB migration, region detection fix, etc.)
+  await runDataMigrations(db, baseDir);
 
   log.info('Database initialized successfully');
 

--- a/src/main/db/migrations/index.ts
+++ b/src/main/db/migrations/index.ts
@@ -1,0 +1,37 @@
+import path from 'node:path';
+import logger from 'electron-log/main';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import type { schema } from '@/main/db';
+import { migrateLowdbToSqlite } from './migrate-from-lowdb';
+import { migrateRegionDetection } from './migrate-region-detection';
+import { migrateFileCrc32 } from './migrate-filecrc32';
+
+const log = logger.scope('db:migrations');
+
+export type AppDatabase = BetterSQLite3Database<typeof schema>;
+
+export function getMigrationsDir(baseDir: string): string {
+  return path.join(baseDir, '.migrations');
+}
+
+/**
+ * Runs all data migrations in order.
+ * These are distinct from Drizzle schema migrations - they transform
+ * existing data to match updated business logic.
+ *
+ * Each migration is self-contained and responsible for:
+ * - Creating its marker directory if needed
+ * - Checking if it has already run (via marker file)
+ * - Performing the migration atomically
+ * - Writing its completion marker
+ */
+export async function runDataMigrations(db: AppDatabase, baseDir: string): Promise<void> {
+  log.info('Running data migrations...');
+
+  // Run migrations in order - add new migrations to the end
+  await migrateLowdbToSqlite(db, baseDir);
+  await migrateRegionDetection(db, baseDir);
+  await migrateFileCrc32(db, baseDir);
+
+  log.info('Data migrations completed');
+}

--- a/src/main/db/migrations/migrate-filecrc32.ts
+++ b/src/main/db/migrations/migrate-filecrc32.ts
@@ -1,0 +1,93 @@
+import logger from 'electron-log/main';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { eq, sql } from 'drizzle-orm';
+import { crc32sum, fileExists } from '@/main/roms/romUtils';
+import { schema } from '@/main/db';
+import { getMigrationsDir } from './index';
+
+const log = logger.scope('db:filecrc32-migration');
+
+type AppDatabase = BetterSQLite3Database<typeof schema>;
+
+/**
+ * Migrates fileCrc32 for archive ROMs to use the source file hash.
+ *
+ * Previously, fileCrc32 was calculated from the ROM content inside archives.
+ * This migration recalculates it from the actual archive file on disk so that
+ * post-sync verification works correctly.
+ *
+ * Addresses issue #103: ZIP files fail hash verification after syncing
+ */
+export async function migrateFileCrc32(db: AppDatabase, baseDir: string) {
+  const migrationsDir = getMigrationsDir(baseDir);
+  fs.mkdirSync(migrationsDir, { recursive: true });
+  const markerPath = path.join(migrationsDir, 'filecrc32-v1');
+
+  if (fs.existsSync(markerPath)) {
+    log.info('fileCrc32 migration already completed, skipping');
+    return;
+  }
+
+  log.info('Starting fileCrc32 migration for archive ROMs...');
+
+  try {
+    // Only select ROMs with archive file extensions (case-insensitive)
+    // Select only columns needed for migration to reduce memory usage
+    const archiveRoms = await db
+      .select({
+        id: schema.roms.id,
+        filePath: schema.roms.filePath,
+        filename: schema.roms.filename,
+        fileCrc32: schema.roms.fileCrc32,
+      })
+      .from(schema.roms)
+      .where(
+        sql`lower(${schema.roms.filename}) like '%.zip' or lower(${schema.roms.filename}) like '%.7z'`
+      );
+
+    let updatedCount = 0;
+    let skippedCount = 0;
+    let missingCount = 0;
+
+    log.info(`Found ${archiveRoms.length} archive ROMs to migrate`);
+
+    for (const rom of archiveRoms) {
+      // Verify source file still exists
+      if (!(await fileExists(rom.filePath))) {
+        log.warn(`Source file missing, skipping: ${rom.filePath}`);
+        missingCount++;
+        continue;
+      }
+
+      try {
+        const newCrc32 = await crc32sum({ filePath: rom.filePath });
+
+        if (newCrc32 !== rom.fileCrc32) {
+          await db
+            .update(schema.roms)
+            .set({ fileCrc32: newCrc32 })
+            .where(eq(schema.roms.id, rom.id));
+
+          updatedCount++;
+          log.debug(`Updated CRC32 for "${rom.filename}": ${rom.fileCrc32} → ${newCrc32}`);
+        } else {
+          skippedCount++;
+        }
+      } catch (error) {
+        log.error(`Failed to hash ${rom.filename}:`, error);
+        skippedCount++;
+      }
+    }
+
+    fs.writeFileSync(markerPath, new Date().toISOString());
+
+    log.info(
+      `fileCrc32 migration completed: ${updatedCount} updated, ${skippedCount} unchanged, ${missingCount} missing`
+    );
+  } catch (error) {
+    log.error('fileCrc32 migration failed:', error);
+    throw error;
+  }
+}

--- a/src/main/db/migrations/migrate-from-lowdb.ts
+++ b/src/main/db/migrations/migrate-from-lowdb.ts
@@ -3,10 +3,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import type { RomDatabase } from '@/types/rom';
-import { schema } from './index';
-import { ensureDatabaseSchema } from '../roms/romDatabaseMigrations';
+import { schema } from '@/main/db';
+import { ensureDatabaseSchema } from '@/main/roms/romDatabaseMigrations';
 
-const log = logger.scope('db:migration');
+const log = logger.scope('db:lowdb-migration');
 
 type AppDatabase = BetterSQLite3Database<typeof schema>;
 

--- a/src/main/roms/romImport.ts
+++ b/src/main/roms/romImport.ts
@@ -39,7 +39,7 @@ export async function processRomFile(
 
     const ramd5 = ramd5sum(consoleId, romFile);
     const md5 = await md5sum({ filePath: romFile.sourcePath, buffer: romFile.romBuffer });
-    const fileCrc32 = await crc32sum({ filePath: romFile.sourcePath, buffer: romFile.romBuffer });
+    const fileCrc32 = await crc32sum({ filePath: romFile.sourcePath });
     const hashes = { ramd5, md5, fileCrc32 };
 
     log.debug(

--- a/src/types/rom.ts
+++ b/src/types/rom.ts
@@ -50,10 +50,11 @@ export interface Rom {
   updatedAt: Date;
   /** MD5 hash of ROM content - primary deduplication method */
   md5: string;
-  /** CRC32 of actual file on disk - fast file integrity checking */
+  /** CRC32 of source file on disk (archive or raw ROM) - used for sync integrity verification */
   fileCrc32: string;
   /** RetroAchievements hash - required for game identification */
   ramd5: string | null;
+  /** RetroAchievements verification status indicating if a ROM is eligible for achievements */
   verified: boolean;
   /** Number of achievements available in RetroAchievements (computed at runtime, not stored) */
   numAchievements?: number;


### PR DESCRIPTION
Previously, ZIP/7z files always failed post-sync verification because the checksum was calculated from the ROM inside the archive, not the archive file itself. Now checksums match what actually gets copied.

---
Reorganized data migrations into src/main/db/migrations/ with a runDataMigrations() runner. Existing archive ROMs get their checksums recalculated on first launch.

Fixes #103