### PR TITLE
feat: add native menu with About and Check for Updates

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ import { getInstanceId } from '@main/analytics';
 import { initializeTheme } from '@main/themes';
 import { initializeUpdater } from '@main/updater';
 import { initializeDatabase } from '@main/db';
+import { initializeMenu } from '@main/menu';
 
 // Initialize sentry for error tracking
 if (process.env.NODE_ENV !== 'development') {
@@ -70,6 +71,16 @@ const createWindow = () => {
       mainWindow.webContents.send('dark-mode:change', shouldUseDarkColors);
     }
   });
+
+  // Set up the About panel
+  app.setAboutPanelOptions({
+    applicationName: 'ROMie',
+    applicationVersion: app.getVersion(),
+    copyright: '© 2025 JZimz',
+  });
+
+  // Initialize the application menu
+  initializeMenu(mainWindow);
 
   // Initialize the auto-updater
   initializeUpdater(mainWindow);

--- a/src/main/menu/index.ts
+++ b/src/main/menu/index.ts
@@ -1,0 +1,98 @@
+import { app, Menu, shell, type BrowserWindow, type MenuItemConstructorOptions } from 'electron';
+import { checkForUpdates, quitAndInstall } from '@main/updater';
+import { isUpdateReady, UPDATE_MENU_ITEM_ID } from './state';
+
+export { setUpdateMenuStatus } from './state';
+
+function handleUpdateMenuClick(mainWindow: BrowserWindow): void {
+  if (isUpdateReady()) {
+    quitAndInstall();
+  } else {
+    checkForUpdates(mainWindow);
+  }
+}
+
+export function initializeMenu(mainWindow: BrowserWindow): void {
+  const isMac = process.platform === 'darwin';
+
+  const template: MenuItemConstructorOptions[] = isMac
+    ? [
+        {
+          label: app.name,
+          submenu: [
+            { role: 'about' },
+            { type: 'separator' },
+            {
+              id: UPDATE_MENU_ITEM_ID,
+              label: 'Check for Updates…',
+              click: () => handleUpdateMenuClick(mainWindow),
+            },
+            { type: 'separator' },
+            { role: 'services' },
+            { type: 'separator' },
+            { role: 'hide' },
+            { role: 'hideOthers' },
+            { role: 'unhide' },
+            { type: 'separator' },
+            { role: 'quit' },
+          ],
+        },
+        {
+          label: 'Edit',
+          submenu: [
+            { role: 'undo' },
+            { role: 'redo' },
+            { type: 'separator' },
+            { role: 'cut' },
+            { role: 'copy' },
+            { role: 'paste' },
+            { role: 'selectAll' },
+          ],
+        },
+        {
+          label: 'Help',
+          submenu: [
+            {
+              label: 'Report an Issue',
+              click: () => shell.openExternal('https://github.com/JZimz/romie/issues'),
+            },
+          ],
+        },
+      ]
+    : [
+        {
+          label: 'Edit',
+          submenu: [
+            { role: 'undo' },
+            { role: 'redo' },
+            { type: 'separator' },
+            { role: 'cut' },
+            { role: 'copy' },
+            { role: 'paste' },
+            { role: 'selectAll' },
+          ],
+        },
+        {
+          label: 'Help',
+          submenu: [
+            {
+              label: 'About ROMie',
+              click: () => app.showAboutPanel(),
+            },
+            {
+              id: UPDATE_MENU_ITEM_ID,
+              label: 'Check for Updates…',
+              click: () => handleUpdateMenuClick(mainWindow),
+            },
+            { type: 'separator' },
+            {
+              label: 'Report an Issue',
+              click: () => shell.openExternal('https://github.com/JZimz/romie/issues'),
+            },
+          ],
+        },
+      ];
+
+  const menu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(menu);
+}

--- a/src/main/menu/state.ts
+++ b/src/main/menu/state.ts
@@ -1,0 +1,32 @@
+import { Menu } from 'electron';
+
+const UPDATE_MENU_ITEM_ID = 'check-for-updates';
+
+export type UpdateMenuStatus = 'idle' | 'checking' | 'ready';
+
+let updateReady = false;
+
+export function isUpdateReady(): boolean {
+  return updateReady;
+}
+
+export function setUpdateMenuStatus(status: UpdateMenuStatus): void {
+  if (status === 'ready') updateReady = true;
+
+  const menu = Menu.getApplicationMenu();
+  if (!menu) return;
+
+  const menuItem = menu.getMenuItemById(UPDATE_MENU_ITEM_ID);
+  if (!menuItem) return;
+
+  const config = {
+    idle: { label: 'Check for Updates…', enabled: true },
+    checking: { label: 'Checking for Updates…', enabled: false },
+    ready: { label: 'Restart to Update…', enabled: true },
+  }[status];
+
+  menuItem.label = config.label;
+  menuItem.enabled = config.enabled;
+}
+
+export { UPDATE_MENU_ITEM_ID };

--- a/src/main/updater/index.ts
+++ b/src/main/updater/index.ts
@@ -1,8 +1,11 @@
-import { autoUpdater, type BrowserWindow } from 'electron';
+import { autoUpdater, dialog, type BrowserWindow } from 'electron';
 import logger from 'electron-log/main';
 import { updateElectronApp, UpdateSourceType } from 'update-electron-app';
+import { setUpdateMenuStatus } from '@main/menu/state';
 
 const log = logger.scope('updater');
+
+let isChecking = false;
 
 export function initializeUpdater(mainWindow: BrowserWindow): void {
   log.info(`Initializing auto-updates for ${process.platform} ${process.arch}`);
@@ -17,6 +20,71 @@ export function initializeUpdater(mainWindow: BrowserWindow): void {
       mainWindow.webContents.send('update:ready', releaseName);
     },
   });
+
+  autoUpdater.on('update-downloaded', () => {
+    setUpdateMenuStatus('ready');
+  });
+}
+
+export function checkForUpdates(mainWindow: BrowserWindow): void {
+  if (isChecking) return;
+  isChecking = true;
+
+  log.info('Manual update check triggered');
+  setUpdateMenuStatus('checking');
+
+  const cleanup = () => {
+    isChecking = false;
+    autoUpdater.removeListener('update-downloaded', onUpdateDownloaded);
+    autoUpdater.removeListener('update-not-available', onUpdateNotAvailable);
+    autoUpdater.removeListener('error', onError);
+  };
+
+  const onUpdateDownloaded = async () => {
+    cleanup();
+    const { response } = await dialog.showMessageBox(mainWindow, {
+      type: 'info',
+      title: 'Update Available',
+      message: 'A new version is ready to install!',
+      detail: 'Restart ROMie to apply the update.',
+      buttons: ['Restart', 'Later'],
+      defaultId: 0,
+    });
+    if (response === 0) {
+      quitAndInstall();
+    }
+  };
+
+  const onUpdateNotAvailable = () => {
+    cleanup();
+    setUpdateMenuStatus('idle');
+    dialog.showMessageBox(mainWindow, {
+      type: 'info',
+      title: 'No Updates Available',
+      message: "You're up to date!",
+      detail: 'ROMie is running the latest version.',
+      buttons: ['OK'],
+    });
+  };
+
+  const onError = (error: Error) => {
+    cleanup();
+    setUpdateMenuStatus('idle');
+    log.error('Update check failed:', error);
+    dialog.showMessageBox(mainWindow, {
+      type: 'error',
+      title: 'Update Check Failed',
+      message: 'Could not check for updates',
+      detail: 'Please check your internet connection and try again.',
+      buttons: ['OK'],
+    });
+  };
+
+  autoUpdater.once('update-downloaded', onUpdateDownloaded);
+  autoUpdater.once('update-not-available', onUpdateNotAvailable);
+  autoUpdater.once('error', onError);
+
+  autoUpdater.checkForUpdates();
 }
 
 export function quitAndInstall(): void {


### PR DESCRIPTION
ROMie now has a native application menu. On macOS it's in the app menu, on Windows/Linux press Alt to reveal the menu bar and find it under Help. You can see the current version via About and manually check for updates instead of waiting for the automatic check.

Fixes #105