### PR TITLE
feat: add AppImage and RPM build outputs for Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       # Detect pre-release tags (e.g., v1.0.0-rc.1, v1.0.0-beta.2)
@@ -74,6 +74,10 @@ jobs:
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
             echo "BUILD_CMD=publish" >> $GITHUB_ENV
           fi
+
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y rpm squashfs-tools
 
       - name: Install dependencies
         run: npm ci
@@ -141,6 +145,8 @@ jobs:
           files: |
             artifacts/**/*.zip
             artifacts/**/*.deb
+            artifacts/**/*.rpm
+            artifacts/**/*.AppImage
             artifacts/**/*.exe
           body_path: CHANGELOG.md
           prerelease: ${{ needs.build.outputs.is_prerelease == 'true' }}

--- a/forge.config.js
+++ b/forge.config.js
@@ -133,6 +133,35 @@ export default {
         },
       },
     },
+    {
+      name: '@electron-forge/maker-rpm',
+      config: {
+        options: {
+          name: 'romie',
+          productName: 'ROMie',
+          bin: 'ROMie',
+          genericName: 'ROM Manager',
+          description: 'ROM Manager for Retro Handhelds',
+          categories: ['Utility', 'Game'],
+          homepage: 'https://github.com/JZimz/romie',
+          icon: 'src/assets/icons/app/png/512x512.png',
+          license: 'MIT',
+        },
+      },
+    },
+    {
+      name: '@reforged/maker-appimage',
+      config: {
+        options: {
+          name: 'romie',
+          bin: 'ROMie',
+          productName: 'ROMie',
+          genericName: 'ROM Manager',
+          icon: 'src/assets/icons/app/png/512x512.png',
+          categories: ['Utility', 'Game'],
+        },
+      },
+    },
   ],
   publishers: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@electron-forge/plugin-vite": "^7.10.2",
         "@electron-forge/publisher-s3": "^7.10.2",
         "@electron/fuses": "^1.8.0",
+        "@reforged/maker-appimage": "^5.1.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node-7z": "^2.1.11",
         "@typescript-eslint/eslint-plugin": "^8.51.0",
@@ -4725,6 +4726,37 @@
         "@opentelemetry/api": "^1.8"
       }
     },
+    "node_modules/@reforged/maker-appimage": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-appimage/-/maker-appimage-5.1.1.tgz",
+      "integrity": "sha512-KjuMp2UXY2Tca/82J+ocWfNFCULBgBPJugDFn/qOgMfT9rPwmvTMjjJpc4AgtTWIpYJ2eytYbGdi1HLx/pvGQg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@electron-forge/maker-base": "^6.0.0 || ^7.0.0",
+        "@reforged/maker-types": "^2.0.0",
+        "@spacingbat3/lss": "^1.0.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=19.0.0 || ^18.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
+    "node_modules/@reforged/maker-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@reforged/maker-types/-/maker-types-2.0.0.tgz",
+      "integrity": "sha512-Vc8xblKLfo+CP7CE/5Yshtyo6NwBkE4ZW00boCI50yePHG2wN04w1qrFlSxAmuau70J3alMhUrByeMrddlxAyw==",
+      "dev": true,
+      "license": "ISC",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
     "node_modules/@retroachievements/api": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/@retroachievements/api/-/api-2.7.0.tgz",
@@ -6172,6 +6204,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@spacingbat3/lss": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@spacingbat3/lss/-/lss-1.2.0.tgz",
+      "integrity": "sha512-aywhxHNb6l7COooF3m439eT/6QN8E/RSl5IVboSKthMHcp0GlZYMSoS7546rqDLmFRxTD8f1tu/NIS9vtDwYAg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@electron-forge/plugin-vite": "^7.10.2",
     "@electron-forge/publisher-s3": "^7.10.2",
     "@electron/fuses": "^1.8.0",
+    "@reforged/maker-appimage": "^5.1.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node-7z": "^2.1.11",
     "@typescript-eslint/eslint-plugin": "^8.51.0",


### PR DESCRIPTION
Linux releases now include .rpm and .AppImage formats alongside .deb. AppImage runs on any distro without installation - just download and run.

---
Uses @reforged/maker-appimage (native TypeScript implementation) instead of electron-forge-maker-appimage (electron-builder wrapper). CI installs rpm and squashfs-tools on Ubuntu runners to build both formats.

Closes #75