### PR TITLE
feat: remember window size and position across sessions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import { initializeTheme } from '@main/themes';
 import { initializeUpdater } from '@main/updater';
 import { initializeDatabase } from '@main/db';
 import { initializeMenu } from '@main/menu';
+import { loadWindowState, trackWindowState } from '@main/window';
 
 // Initialize sentry for error tracking
 if (process.env.NODE_ENV !== 'development') {
@@ -25,13 +26,16 @@ if (started) {
 }
 
 const createWindow = () => {
+  const windowState = loadWindowState();
   const mainWindow = new BrowserWindow({
-    width: 1000,
-    height: 600,
+    width: windowState.bounds.width,
+    height: windowState.bounds.height,
+    x: windowState.bounds.x,
+    y: windowState.bounds.y,
     minWidth: 900,
     minHeight: 480,
     // Remove the window frame
-    frame: 'false',
+    frame: false,
     // Hide the title bar but keep traffic lights on MacOS
     titleBarStyle: process.platform === 'darwin' ? 'hidden' : 'default',
     // Hide the menu bar in windows and linux
@@ -40,6 +44,14 @@ const createWindow = () => {
       preload: path.join(__dirname, 'preload.js'),
     },
   });
+
+  // Restore maximized state after window is ready
+  if (windowState.isMaximized) {
+    mainWindow.maximize();
+  }
+
+  // Track and persist window state changes
+  trackWindowState(mainWindow);
 
   // and load the index.html of the app.
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {

--- a/src/main/window/index.ts
+++ b/src/main/window/index.ts
@@ -1,0 +1,83 @@
+import { screen } from 'electron';
+import type { BrowserWindow } from 'electron';
+import logger from 'electron-log/main';
+import { settings } from '@main/db/queries';
+import type { WindowState } from '@/types/settings';
+
+const log = logger.scope('window');
+
+const DEFAULT_WINDOW_STATE: WindowState = {
+  bounds: { width: 1000, height: 600 },
+  isMaximized: false,
+};
+
+export function loadWindowState(): WindowState {
+  try {
+    const stored = settings.get('windowState');
+    if (!stored) return DEFAULT_WINDOW_STATE;
+
+    const state: WindowState = JSON.parse(stored);
+    const { bounds } = state;
+
+    // If position was saved, validate it's visible on at least one display
+    if (bounds.x !== undefined && bounds.y !== undefined) {
+      const savedX = bounds.x;
+      const savedY = bounds.y;
+      const displays = screen.getAllDisplays();
+      const isVisible = displays.some((display) => {
+        const { x, y, width, height } = display.bounds;
+        return savedX >= x && savedX < x + width && savedY >= y && savedY < y + height;
+      });
+
+      if (!isVisible) {
+        log.debug('Saved window position is off-screen, centering window');
+        return {
+          bounds: { width: bounds.width, height: bounds.height },
+          isMaximized: state.isMaximized,
+        };
+      }
+    }
+
+    return state;
+  } catch (error) {
+    log.warn('Failed to load window state:', error);
+    return DEFAULT_WINDOW_STATE;
+  }
+}
+
+function saveWindowState(window: BrowserWindow): void {
+  if (window.isDestroyed()) return;
+
+  try {
+    const isMaximized = window.isMaximized();
+    const bounds = isMaximized ? loadWindowState().bounds : window.getBounds();
+
+    const state: WindowState = { bounds, isMaximized };
+    settings.set('windowState', JSON.stringify(state));
+  } catch (error) {
+    log.warn('Failed to save window state:', error);
+  }
+}
+
+const saveTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
+
+function saveWindowStateDebounced(window: BrowserWindow): void {
+  const existing = saveTimeouts.get(window.id);
+  if (existing) clearTimeout(existing);
+  saveTimeouts.set(
+    window.id,
+    setTimeout(() => {
+      // eslint-disable-next-line drizzle/enforce-delete-with-where
+      saveTimeouts.delete(window.id);
+      saveWindowState(window);
+    }, 500)
+  );
+}
+
+export function trackWindowState(window: BrowserWindow): void {
+  window.on('resize', () => saveWindowStateDebounced(window));
+  window.on('move', () => saveWindowStateDebounced(window));
+  window.on('maximize', () => saveWindowState(window));
+  window.on('unmaximize', () => saveWindowState(window));
+  window.on('close', () => saveWindowState(window));
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,7 +1,20 @@
 export type AppTheme = 'light' | 'dark' | 'system';
 
+export interface WindowBounds {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+}
+
+export interface WindowState {
+  bounds: WindowBounds;
+  isMaximized: boolean;
+}
+
 export interface AppSettings {
   theme: AppTheme;
+  windowState?: WindowState;
 }
 
 export interface RetroAchievementsConfig {


### PR DESCRIPTION
The app now opens where you left it - same size, same spot, same monitor. If you had it maximized, it'll open maximized again.

---
Window state persists to the settings table as JSON. Validates saved position is still on a connected display to handle monitor changes gracefully.