### PR TITLE
feat: add ROM file existence checks

### DIFF
--- a/src/components/AppToolbar.vue
+++ b/src/components/AppToolbar.vue
@@ -10,6 +10,30 @@
       >
         {{ updateAvailable }} is ready! Click here to restart and install the update.
       </Message>
+      <Message
+        v-if="unavailableCount > 0 && !unavailableDismissed"
+        class="app-toolbar__unavailable-message"
+        severity="warn"
+        size="small"
+        :closable="true"
+        @close="unavailableDismissed = true"
+      >
+        <a
+          href="#"
+          class="app-toolbar__unavailable-count"
+          @click.prevent="emit('filter-unavailable')"
+        >
+          {{ unavailableCount }} {{ pluralize(unavailableCount, 'ROM') }}
+        </a>
+        {{ pluralize(unavailableCount, 'has', 'have') }} missing or moved files.
+        <a
+          href="#"
+          class="app-toolbar__unavailable-action"
+          @click.prevent="handleRemoveUnavailable"
+        >
+          Remove from library
+        </a>
+      </Message>
     </div>
     <div class="app-toolbar__tools">
       <div class="app-toolbar__actions">
@@ -39,10 +63,26 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue';
 import Button from 'primevue/button';
 import Message from 'primevue/message';
+import { useConfirm } from 'primevue/useconfirm';
 import AppSettingsModal from '@/components/AppSettingsModal.vue';
+import { pluralize } from '@/utils/string.utils';
 
+const props = withDefaults(
+  defineProps<{
+    unavailableCount?: number;
+  }>(),
+  { unavailableCount: 0 }
+);
+
+const emit = defineEmits<{
+  (e: 'filter-unavailable'): void;
+  (e: 'remove-unavailable'): void;
+}>();
+
+const confirm = useConfirm();
 const settingsModal = ref();
 const updateAvailable = ref<string | null>(null);
+const unavailableDismissed = ref(false);
 let unsubscribeUpdates: (() => void) | null = null;
 
 onMounted(() => {
@@ -58,6 +98,16 @@ onBeforeUnmount(() => {
 function handleUpdate() {
   window.update.quitAndInstall();
 }
+
+function handleRemoveUnavailable() {
+  confirm.require({
+    header: 'Remove Unavailable ROMs',
+    message: `Are you sure you want to remove ${props.unavailableCount} unavailable ${pluralize(props.unavailableCount, 'ROM')} from your library?`,
+    rejectProps: { label: 'Cancel', severity: 'secondary', outlined: true },
+    acceptProps: { label: 'Remove All', severity: 'danger' },
+    accept: () => emit('remove-unavailable'),
+  });
+}
 </script>
 
 <style scoped lang="less">
@@ -67,6 +117,17 @@ function handleUpdate() {
     cursor: pointer;
     user-select: none;
   }
+
+  &__unavailable-count,
+  &__unavailable-action {
+    font-weight: 600;
+    color: inherit;
+  }
+
+  &__unavailable-action {
+    margin-left: 4px;
+  }
+
   &__messages {
     .p-message {
       border-radius: 0;
@@ -88,6 +149,7 @@ function handleUpdate() {
 
   /* All interactive elements need to be above the drag region */
   :deep(button),
+  :deep(a),
   :deep(input),
   :deep(select),
   :deep(.p-button),
@@ -97,6 +159,7 @@ function handleUpdate() {
   &__update-message {
     z-index: var(--z-index-ui-elements);
     -webkit-app-region: no-drag;
+    position: relative;
   }
 }
 </style>

--- a/src/components/RomList.vue
+++ b/src/components/RomList.vue
@@ -15,6 +15,7 @@
         :region="rom.region"
         :size="rom.size"
         :is-active="romSelections.includes(rom.id)"
+        :available="!!rom.filePathExists"
         @click="handleRomClick($event, rom)"
       />
     </template>

--- a/src/components/RomListItem.vue
+++ b/src/components/RomListItem.vue
@@ -1,10 +1,21 @@
 <template>
   <div class="rom-list-item-wrapper">
-    <div class="rom-list-item" :class="{ 'rom-list-item--active': isActive }">
+    <div
+      class="rom-list-item"
+      :class="{
+        'rom-list-item--active': isActive,
+        'rom-list-item--unavailable': !available,
+      }"
+    >
       <SystemBadge :code="system" />
       <div class="rom-list-item__content">
         <span class="rom-list-item__name">{{ name }}</span>
         <span class="rom-list-item__region">{{ region }}</span>
+        <i
+          v-if="!available"
+          v-tooltip.top="'File not found'"
+          class="pi pi-exclamation-circle rom-list-item__warning"
+        />
       </div>
       <div class="rom-list-item__actions"></div>
     </div>
@@ -16,14 +27,20 @@ import SystemBadge from '@/components/SystemBadge.vue';
 
 import type { SystemCode } from '@/types/system';
 
-defineProps<{
-  id: string;
-  name: string;
-  system: SystemCode;
-  region: string;
-  size: number;
-  isActive: boolean;
-}>();
+withDefaults(
+  defineProps<{
+    id: string;
+    name: string;
+    system: SystemCode;
+    region: string;
+    size: number;
+    isActive: boolean;
+    available?: boolean;
+  }>(),
+  {
+    available: true,
+  }
+);
 </script>
 
 <style scoped lang="less">
@@ -68,6 +85,20 @@ defineProps<{
   &__actions {
     flex-shrink: 0;
     margin-left: auto;
+  }
+
+  &__warning {
+    margin-left: 6px;
+    color: var(--p-yellow-600);
+    font-size: 0.75rem;
+  }
+
+  &--unavailable {
+    opacity: 0.5;
+
+    .rom-list-item__name {
+      color: var(--p-text-muted-color);
+    }
   }
 }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import { initializeUpdater } from '@main/updater';
 import { initializeDatabase } from '@main/db';
 import { initializeMenu } from '@main/menu';
 import { loadWindowState, trackWindowState } from '@main/window';
+import { checkRomAvailability } from '@main/roms/romValidation';
 
 // Initialize sentry for error tracking
 if (process.env.NODE_ENV !== 'development') {
@@ -121,6 +122,7 @@ app
     await initializeDatabase();
     registerAllIpc();
     await initializeTheme();
+    await checkRomAvailability();
 
     createWindow();
 

--- a/src/main/db/queries/roms.ts
+++ b/src/main/db/queries/roms.ts
@@ -1,4 +1,4 @@
-import { eq, count, sum } from 'drizzle-orm';
+import { eq, count, sum, inArray } from 'drizzle-orm';
 import { db, schema } from '@main/db';
 import type { Rom } from '@/types/rom';
 import type { SystemCode } from '@/types/system';
@@ -34,8 +34,10 @@ export const romsQueries = {
       .run();
   },
 
-  remove(id: string) {
-    db.delete(schema.roms).where(eq(schema.roms.id, id)).run();
+  remove(ids: string | string[]) {
+    const idArray = Array.isArray(ids) ? ids : [ids];
+    if (idArray.length === 0) return;
+    db.delete(schema.roms).where(inArray(schema.roms.id, idArray)).run();
   },
 
   count() {

--- a/src/main/ipc/rom.js
+++ b/src/main/ipc/rom.js
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron';
 import { scanRomDirectory } from '@main/roms/romService';
 import { listRoms, removeRomById, getRomStats, updateRom } from '@main/roms/romDatabase';
+import { checkRomAvailability } from '@main/roms/romValidation';
 
 export function registerRomIpc() {
   ipcMain.handle('rom:scan', scanRomDirectory);
@@ -8,4 +9,5 @@ export function registerRomIpc() {
   ipcMain.handle('rom:remove', (_, id) => removeRomById(id));
   ipcMain.handle('rom:update', (_, id, data) => updateRom(id, data));
   ipcMain.handle('rom:stats', () => getRomStats());
+  ipcMain.handle('rom:refresh', checkRomAvailability);
 }

--- a/src/main/roms/romValidation.ts
+++ b/src/main/roms/romValidation.ts
@@ -1,0 +1,32 @@
+import { access, constants } from 'node:fs/promises';
+import logger from 'electron-log/main';
+import { roms } from '@/main/db/queries';
+
+import type { Rom } from '@/types/rom';
+
+const log = logger.scope('rom-validation');
+const availabilityCache = new Map<string, boolean>();
+
+export async function checkRomAvailability(): Promise<void> {
+  log.info('Checking ROM file availability on disk...');
+  availabilityCache.clear();
+  const allRoms = roms.list();
+
+  await Promise.all(allRoms.map((rom) => validateRomExists(rom)));
+}
+
+export async function validateRomExists(rom: Rom): Promise<boolean> {
+  const cached = availabilityCache.get(rom.id);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    await access(rom.filePath, constants.R_OK);
+    availabilityCache.set(rom.id, true);
+    return true;
+  } catch {
+    availabilityCache.set(rom.id, false);
+    return false;
+  }
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -32,10 +32,11 @@ if (process.env.NODE_ENV !== 'development') {
 
 const romApi: RomApi = {
   list: () => ipcRenderer.invoke('rom:list'),
-  remove: (id: string) => ipcRenderer.invoke('rom:remove', id),
+  remove: (ids: string | string[]) => ipcRenderer.invoke('rom:remove', ids),
   update: (id: string, data: Partial<Rom>) => ipcRenderer.invoke('rom:update', id, data),
   scan: () => ipcRenderer.invoke('rom:scan'),
   stats: () => ipcRenderer.invoke('rom:stats'),
+  refresh: () => ipcRenderer.invoke('rom:refresh'),
   onImportProgress: (callback: (progress: ImportStatus) => void) => {
     const handler = (_event: IpcRendererEvent, progress: ImportStatus) => callback(progress);
     ipcRenderer.on('rom:import-progress', handler);

--- a/src/stores/roms.ts
+++ b/src/stores/roms.ts
@@ -87,12 +87,13 @@ export const useRomStore = defineStore('roms', {
         throw error;
       }
     },
-    async removeRom(id: string) {
-      log.info(`Removing ${id}`);
+    async removeRoms(ids: string[]) {
+      if (ids.length === 0) return;
+      log.info(`Removing ${ids.length} ROMs`);
       this.loading = true;
 
       try {
-        await window.rom.remove(id);
+        await window.rom.remove([...ids]);
         await this.loadRoms();
         await this.loadStats();
       } catch (error) {
@@ -124,6 +125,21 @@ export const useRomStore = defineStore('roms', {
       await this.loadStats();
 
       return scanResults;
+    },
+    async refreshRomAvailability() {
+      log.info('Refreshing rom availability..');
+      this.loading = true;
+
+      try {
+        await window.rom.refresh();
+        await this.loadRoms();
+        await this.loadStats();
+      } catch (error) {
+        log.error(error);
+        throw error;
+      } finally {
+        this.loading = false;
+      }
     },
   },
 });

--- a/src/types/electron-api.ts
+++ b/src/types/electron-api.ts
@@ -33,10 +33,11 @@ export interface ImportStatus {
 
 export interface RomApi {
   list(): Promise<Rom[]>;
-  remove(id: string): Promise<void>;
+  remove(ids: string | string[]): Promise<void>;
   update(id: string, romUpdate: Partial<Rom>): Promise<void>;
   scan(): Promise<RomImportResult>;
   stats(): Promise<RomDatabaseStats>;
+  refresh(): Promise<void>;
   onImportProgress(callback: (progress: ImportStatus) => void): () => void;
 }
 

--- a/src/types/rom.ts
+++ b/src/types/rom.ts
@@ -56,11 +56,13 @@ export interface Rom {
   ramd5: string | null;
   /** RetroAchievements verification status indicating if a ROM is eligible for achievements */
   verified: boolean;
-  /** Number of achievements available in RetroAchievements (computed at runtime, not stored) */
-  numAchievements?: number;
   tags?: string[] | null;
   favorite?: boolean | null;
   notes?: string | null;
+  /** Whether the file path exists on disk (computed at runtime, not stored) */
+  filePathExists?: boolean;
+  /** Number of achievements available in RetroAchievements (computed at runtime, not stored) */
+  numAchievements?: number;
 
   /** @deprecated Use `createdAt` instead */
   importedAt?: number;

--- a/src/views/RomDetailView.vue
+++ b/src/views/RomDetailView.vue
@@ -27,6 +27,16 @@
       </template>
       <template #content>
         <div class="rom-details__content">
+          <Message v-if="!rom.filePathExists" severity="warn" :closable="false">
+            <p class="rom-details__alert-text">
+              The ROM file could not be located. It may have been moved, deleted, or is on a
+              disconnected drive.
+            </p>
+            <code class="rom-details__alert-path">{{ rom.filePath }}</code>
+            <p class="rom-details__alert-hint">
+              Use the <strong>Delete</strong> button below to remove this ROM from your library.
+            </p>
+          </Message>
           <RomAchievements
             :verified="rom.verified"
             :loading="loading"
@@ -99,6 +109,7 @@ import { computed, ref, watch } from 'vue';
 import Button from 'primevue/button';
 import Card from 'primevue/card';
 import Tag from 'primevue/tag';
+import Message from 'primevue/message';
 import { useToast } from 'primevue/usetoast';
 import { useRomStore, useFeatureFlagStore } from '@/stores';
 import { getSystemDisplayName } from '@/utils/systems';
@@ -195,7 +206,7 @@ async function handleDelete() {
   deleting.value = true;
 
   try {
-    await romStore.removeRom(props.romId);
+    await romStore.removeRoms([props.romId]);
 
     toast.add({
       severity: 'success',
@@ -336,6 +347,27 @@ function formatDatetime(ts: number): string {
 
   &__actions {
     margin-top: 16px;
+  }
+
+  &__alert-text {
+    margin: 0;
+  }
+
+  &__alert-path {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    margin-top: 10px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    word-break: break-all;
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  &__alert-hint {
+    margin: 10px 0 0;
+    font-size: var(--font-size-sm);
+    opacity: 0.85;
   }
 }
 </style>


### PR DESCRIPTION
ROMie now checks that all imported ROMs still exist when the app starts or when clicking "Refresh Library" from the import page.  Warnings are shown for unavailable ROMs with an option to remove them.

Fixes #72