### PR TITLE
fix: update ROM path when reimporting moved files

### DIFF
--- a/src/main/roms/romValidation.ts
+++ b/src/main/roms/romValidation.ts
@@ -15,10 +15,12 @@ export async function checkRomAvailability(): Promise<void> {
   await Promise.all(allRoms.map((rom) => validateRomExists(rom)));
 }
 
-export async function validateRomExists(rom: Rom): Promise<boolean> {
-  const cached = availabilityCache.get(rom.id);
-  if (cached !== undefined) {
-    return cached;
+export async function validateRomExists(rom: Rom, ignoreCache = false): Promise<boolean> {
+  if (!ignoreCache) {
+    const cached = availabilityCache.get(rom.id);
+    if (cached !== undefined) {
+      return cached;
+    }
   }
 
   try {


### PR DESCRIPTION
When ROM files are moved or renamed, reimporting now updates the existing record instead of erroring on duplicate MD5. The update only happens if the original file path is no longer accessible, preventing false duplicates.

Also invalidates the availability cache so the UI immediately reflects the corrected path.

Fixes the issue where renamed ROMs would show as unavailable after reimport.