### PR TITLE
Add MSX / MSX2 system support

### DIFF
--- a/SUPPORTED_SYSTEMS.md
+++ b/SUPPORTED_SYSTEMS.md
@@ -27,9 +27,14 @@ ROMie supports the following gaming systems with automatic ROM detection and org
 - **Atari 2600** (Atari 2600, 1977) - `.a26`
 - **Lynx** (Atari Lynx, 1989) - `.lnx`
 
+### MSX
+
+- **MSX / MSX2** (Various, 1983) - `.dsk`, `.mx1`, `.mx2`, `.rom`, `.cas`, `.m3u`
+
 ### Other Systems
 
 - **Neo Geo Pocket** (SNK Neo Geo Pocket, 1998) - `.ngp`, `.ngc`
+- **PC Engine / TurboGrafx-16** (NEC, 1987) - `.pce`
 - **Arcade** (MAME, 1971+) - `.zip`
 
 ## Archive Files (ZIP/7Z)

--- a/src/packages/device-profiles/src/profiles/knulli.ts
+++ b/src/packages/device-profiles/src/profiles/knulli.ts
@@ -74,6 +74,10 @@ export const KNULLI_PROFILE: DeviceProfile = {
       folderName: 'pcengine',
       supportedFormats: ['.pce', '.zip', '.7z'],
     },
+    msx: {
+      folderName: 'msx',
+      supportedFormats: ['.dsk', '.mx1', '.mx2', '.rom', '.cas', '.m3u', '.zip', '.7z'],
+    },
     arcade: {
       folderName: 'fbneo',
       supportedFormats: ['.zip', '.7z'],

--- a/src/packages/device-profiles/src/profiles/muos.ts
+++ b/src/packages/device-profiles/src/profiles/muos.ts
@@ -85,5 +85,9 @@ export const MUOS_PROFILE: DeviceProfile = {
       folderName: 'vb',
       supportedFormats: ['.vb', '.zip', '.7z'],
     },
+    msx: {
+      folderName: 'msx',
+      supportedFormats: ['.dsk', '.mx1', '.mx2', '.rom', '.cas', '.m3u', '.zip', '.7z'],
+    },
   },
 };

--- a/src/packages/device-profiles/src/profiles/onion.ts
+++ b/src/packages/device-profiles/src/profiles/onion.ts
@@ -77,6 +77,10 @@ export const ONION_OS_PROFILE: DeviceProfile = {
       folderName: 'PCE',
       supportedFormats: ['.pce', '.zip', '.7z'],
     },
+    msx: {
+      folderName: 'MSX',
+      supportedFormats: ['.dsk', '.mx1', '.mx2', '.rom', '.cas', '.m3u', '.zip', '.7z'],
+    },
     arcade: {
       folderName: 'ARCADE',
       supportedFormats: ['.zip', '.7z'],

--- a/src/packages/device-profiles/src/profiles/retroarch.ts
+++ b/src/packages/device-profiles/src/profiles/retroarch.ts
@@ -81,6 +81,10 @@ export const RETROARCH_PROFILE: DeviceProfile = {
       folderName: 'NEC - PC Engine - TurboGrafx-16',
       supportedFormats: ['.pce', '.zip', '.7z'],
     },
+    msx: {
+      folderName: 'Microsoft - MSX',
+      supportedFormats: ['.dsk', '.mx1', '.mx2', '.rom', '.cas', '.m3u', '.zip', '.7z'],
+    },
     arcade: {
       folderName: 'MAME',
       supportedFormats: ['.zip', '.7z'],

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -16,6 +16,7 @@ export const SYSTEM_CODES = [
   'lynx',
   'atari2600',
   'pce',
+  'msx',
   'arcade',
 ] as const;
 

--- a/src/utils/system.utils.ts
+++ b/src/utils/system.utils.ts
@@ -21,6 +21,7 @@ const SYSTEM_COLORS: Record<SystemCode, string> = {
   lynx: '#EA580C', // orange - bright Atari color
   atari2600: '#A16207', // golden brown - retro Atari
   pce: '#D97706', // amber orange - TurboGrafx branding
+  msx: '#CC0000', // red - MSX brand color
   arcade: '#EAB308', // bright yellow - classic arcade
 };
 

--- a/src/utils/systems/index.ts
+++ b/src/utils/systems/index.ts
@@ -26,6 +26,7 @@ export const RA_SYSTEMS: RASystemMapping[] = [
   { consoleId: 25, code: 'atari2600' }, // ATARI_2600
   { consoleId: 27, code: 'arcade' }, // ARCADE
   { consoleId: 28, code: 'vb' }, // VIRTUAL_BOY
+  { consoleId: 29, code: 'msx' }, // MSX
   { consoleId: 41, code: 'psp' }, // PSP
 ];
 

--- a/src/utils/systems/systemRegistry.ts
+++ b/src/utils/systems/systemRegistry.ts
@@ -204,6 +204,19 @@ export const SYSTEM_REGISTRY: Partial<Record<SystemCode, SystemInfo>> = {
     releaseYear: 1987,
   },
 
+  // === MSX ===
+  msx: {
+    code: 'msx',
+    displayName: 'MSX',
+    fullName: 'MSX / MSX2',
+    type: 'console',
+    extensions: ['.dsk', '.mx1', '.mx2', '.rom', '.cas', '.m3u'],
+    aliases: ['msx', 'msx1', 'msx2', 'msx-dos'],
+    requiresBios: false,
+    manufacturer: 'Various (Microsoft licensed)',
+    releaseYear: 1983,
+  },
+
   // === ARCADE ===
   arcade: {
     code: 'arcade',


### PR DESCRIPTION
## What's changed?

Added comprehensive support for MSX / MSX2 gaming systems across the ROMie platform:

- **System Registry**: Added MSX system definition with support for `.dsk`, `.mx1`, `.mx2`, `.rom`, `.cas`, and `.m3u` file formats
- **Device Profiles**: Configured MSX support for all device profiles (Knulli, muOS, Onion OS, and RetroArch) with appropriate folder mappings and format support
- **System Types**: Added `msx` to the system codes enum and configured the brand color (#CC0000 - MSX red)
- **RetroArch Mapping**: Added console ID mapping (29) for MSX systems
- **Documentation**: Updated SUPPORTED_SYSTEMS.md to list MSX as a supported system and reorganized the documentation structure

## Why?

This adds MSX / MSX2 system support to ROMie, enabling users to organize and manage their MSX ROM collections with automatic detection and proper folder organization across all supported device profiles.

## How to test

- Verify MSX appears in the system registry and is properly recognized
- Test ROM detection with various MSX file formats (`.dsk`, `.mx1`, `.mx2`, `.rom`, `.cas`, `.m3u`)
- Confirm MSX ROMs are organized into the correct folders for each device profile (msx/MSX/Microsoft - MSX depending on the profile)
- Verify the MSX system displays with the correct red brand color in the UI

https://claude.ai/code/session_01PZEiMRV8TRzcYAFbsuKsPd