### PR TITLE
feat: stop flagging ROMs as missing when their drive is disconnected

### DIFF
--- a/src/components/RomList.vue
+++ b/src/components/RomList.vue
@@ -15,7 +15,7 @@
         :region="rom.region"
         :size="rom.size"
         :is-active="romSelections.includes(rom.id)"
-        :available="!!rom.filePathExists"
+        :available="!!rom.filePathExists || !!rom.volumeDisconnected"
         @click="handleRomClick($event, rom)"
       />
     </template>

--- a/src/layouts/RomListLayout.vue
+++ b/src/layouts/RomListLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="rom-list-layout">
     <AppToolbar
-      :unavailable-count="unavailableCount"
+      :unavailable-count="missingCount"
       @filter-unavailable="showUnavailableFilter"
       @remove-unavailable="removeUnavailableRoms"
     >
@@ -42,13 +42,14 @@
     <div v-if="showFilters" class="rom-list-layout__filters">
       <FloatLabel variant="on">
         <Select
-          v-if="hasUnavailableRoms || filterByAvailability !== null"
+          v-if="hasMissingRoms || hasDisconnectedRoms || filterByAvailability !== null"
           id="availability_filter"
           v-model="filterByAvailability"
           class="rom-list-layout__availability-filter"
           :options="[
             { label: 'Available', value: 'available' },
-            { label: 'Unavailable', value: 'unavailable' },
+            { label: 'Missing', value: 'missing' },
+            { label: 'Disconnected', value: 'disconnected' },
           ]"
           option-label="label"
           option-value="value"
@@ -158,9 +159,14 @@ const filterByRegion = ref<string[]>([]);
 const filterByRA = ref<AchievementFilter>(null);
 const filterByAvailability = ref<AvailabilityFilter>(null);
 
-const unavailableRoms = computed(() => romStore.roms.filter((rom) => !rom.filePathExists));
-const unavailableCount = computed(() => unavailableRoms.value.length);
-const hasUnavailableRoms = computed(() => unavailableCount.value > 0);
+const missingRoms = computed(() =>
+  romStore.roms.filter((rom) => !rom.filePathExists && !rom.volumeDisconnected)
+);
+const missingCount = computed(() => missingRoms.value.length);
+const hasMissingRoms = computed(() => missingCount.value > 0);
+const hasDisconnectedRoms = computed(() =>
+  romStore.roms.some(({ volumeDisconnected }) => volumeDisconnected)
+);
 
 const searchPlaceholder = computed(() => {
   if (props.mode === 'tag' && props.tag) {
@@ -252,11 +258,11 @@ function toggleFilters() {
 
 function showUnavailableFilter() {
   showFilters.value = true;
-  filterByAvailability.value = 'unavailable';
+  filterByAvailability.value = 'missing';
 }
 
 async function removeUnavailableRoms() {
-  const idsToRemove = unavailableRoms.value.map(({ id }) => id);
+  const idsToRemove = missingRoms.value.map(({ id }) => id);
 
   try {
     await romStore.removeRoms(idsToRemove);

--- a/src/main/ipc/sync.ts
+++ b/src/main/ipc/sync.ts
@@ -172,6 +172,18 @@ function filterRomsForSync(
   log.debug(`Filtering ${allRoms.length} ROMs for tags: ${tagIds.join(', ')}`);
 
   const filteredRoms = allRoms.filter((rom) => {
+    // Skip ROMs on disconnected volumes — they can't be copied right now
+    if (rom.volumeDisconnected) {
+      syncStatus
+        .addSkipped({
+          rom,
+          reason: 'volume_unreachable',
+          details: 'ROM is on a disconnected drive',
+        })
+        .incrementProcessed();
+      return false;
+    }
+
     // Check if ROM has any of the target tags
     if (!rom.tags?.some((tag) => tagIds.includes(tag))) {
       return false;

--- a/src/main/roms/romDatabase.ts
+++ b/src/main/roms/romDatabase.ts
@@ -26,9 +26,10 @@ export async function addRom(rom: RomDraft): Promise<Rom> {
   const existing = roms.findByMd5(rom.md5);
 
   if (existing) {
-    const originalExists = await validateRomExists(existing);
+    const { filePathExists: originalExists, volumeDisconnected } =
+      await validateRomExists(existing);
 
-    if (existing.filePath !== rom.filePath && !originalExists) {
+    if (existing.filePath !== rom.filePath && !originalExists && !volumeDisconnected) {
       // Original file no longer accessible - update the record with new path
       roms.update(existing.id, {
         filePath: rom.filePath,
@@ -82,8 +83,8 @@ export async function listRoms(): Promise<Rom[]> {
   // Enrich ROMs with achievement count and availability data.
   const enrichedRoms = await Promise.all(
     allRoms.map(async (rom) => {
-      const filePathExists = await validateRomExists(rom);
-      const enrichedRom: Rom = { ...rom, filePathExists };
+      const { filePathExists, volumeDisconnected } = await validateRomExists(rom);
+      const enrichedRom: Rom = { ...rom, filePathExists, volumeDisconnected };
 
       if (rom.verified && rom.ramd5) {
         const game = lookupRomByHashSync(rom.ramd5);

--- a/src/main/roms/romValidation.test.ts
+++ b/src/main/roms/romValidation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getVolumeRoot } from './romValidation';
+
+describe('getVolumeRoot', () => {
+  describe('macOS', () => {
+    it('returns the volume root for /Volumes paths', () => {
+      expect(getVolumeRoot('/Volumes/NAS/Roms/SNES/game.sfc', 'darwin')).toBe('/Volumes/NAS');
+      expect(getVolumeRoot('/Volumes/USB Drive/roms/game.rom', 'darwin')).toBe(
+        '/Volumes/USB Drive'
+      );
+    });
+
+    it('returns null for local paths', () => {
+      expect(getVolumeRoot('/Users/jrs/retro/Roms/N64/game.z64', 'darwin')).toBeNull();
+    });
+  });
+
+  describe('Linux', () => {
+    it('returns the volume root for /mnt paths', () => {
+      expect(getVolumeRoot('/mnt/storage/roms/game.rom', 'linux')).toBe('/mnt/storage');
+    });
+
+    it('returns the volume root for /run/media paths', () => {
+      expect(getVolumeRoot('/run/media/jrs/USB/roms/game.rom', 'linux')).toBe('/run/media/jrs/USB');
+    });
+
+    it('returns null for unsupported mount locations', () => {
+      expect(getVolumeRoot('/media/jrs/USB/roms/game.rom', 'linux')).toBeNull();
+      expect(getVolumeRoot('/srv/roms/game.rom', 'linux')).toBeNull();
+    });
+  });
+
+  describe('Windows', () => {
+    it('returns the drive root for any drive letter', () => {
+      expect(getVolumeRoot('C:\\roms\\game.rom', 'win32')).toBe('C:\\');
+      expect(getVolumeRoot('D:\\roms\\game.rom', 'win32')).toBe('D:\\');
+      expect(getVolumeRoot('F:\\roms\\game.rom', 'win32')).toBe('F:\\');
+    });
+  });
+});

--- a/src/main/roms/romValidation.ts
+++ b/src/main/roms/romValidation.ts
@@ -1,34 +1,96 @@
 import { access, constants } from 'node:fs/promises';
+import path from 'node:path';
 import logger from 'electron-log/main';
 import { roms } from '@/main/db/queries';
 
 import type { Rom } from '@/types/rom';
 
 const log = logger.scope('rom-validation');
-const availabilityCache = new Map<string, boolean>();
+
+export interface RomAvailability {
+  filePathExists: boolean;
+  volumeDisconnected: boolean;
+}
+
+const availabilityCache = new Map<string, RomAvailability>();
+const volumeCache = new Map<string, boolean>();
+
+/**
+ * Returns the volume root to check for a given file path, or null if the path
+ * is on a local filesystem that doesn't warrant a volume check.
+ *
+ * Covers common OS mount conventions:
+ *   macOS:   /Volumes/<name>
+ *   Windows: any drive root (C:\, D:\, F:\, etc.)
+ *   Linux:   /mnt/<name>, /run/media/<user>/<name>
+ *
+ * Tradeoff: Simplicity over total accuracy. Volumes mounted outside these
+ * conventions are treated as local, so if they disconnect they will show as
+ * missing rather than disconnected.
+ */
+export function getVolumeRoot(filePath: string, platform = process.platform): string | null {
+  if (platform === 'win32') {
+    return path.win32.parse(filePath).root || null;
+  }
+
+  // macOS: all external/network volumes mount under /Volumes
+  const mac = filePath.match(/^(\/Volumes\/[^/]+)/);
+  if (mac) return mac[1];
+
+  // Linux: common mount locations
+  // /mnt/<name>              — manual mounts
+  // /run/media/<user>/<name> — udisks2 automount (Arch, Fedora, modern Ubuntu)
+  const linux = filePath.match(/^\/(mnt\/[^/]+|run\/media\/[^/]+\/[^/]+)/);
+  if (linux) return '/' + linux[1];
+
+  return null;
+}
+
+async function isVolumeAccessible(volumeRoot: string): Promise<boolean> {
+  const cached = volumeCache.get(volumeRoot);
+  if (cached !== undefined) return cached;
+
+  try {
+    await access(volumeRoot, constants.R_OK);
+    volumeCache.set(volumeRoot, true);
+    return true;
+  } catch {
+    volumeCache.set(volumeRoot, false);
+    return false;
+  }
+}
 
 export async function checkRomAvailability(): Promise<void> {
   log.info('Checking ROM file availability on disk...');
   availabilityCache.clear();
+  volumeCache.clear();
   const allRoms = roms.list();
 
   await Promise.all(allRoms.map((rom) => validateRomExists(rom)));
 }
 
-export async function validateRomExists(rom: Rom, ignoreCache = false): Promise<boolean> {
+export async function validateRomExists(rom: Rom, ignoreCache = false): Promise<RomAvailability> {
   if (!ignoreCache) {
     const cached = availabilityCache.get(rom.id);
-    if (cached !== undefined) {
-      return cached;
+    if (cached !== undefined) return cached;
+  }
+
+  const volumeRoot = getVolumeRoot(rom.filePath);
+  const volumeAccessible = volumeRoot === null || (await isVolumeAccessible(volumeRoot));
+
+  let result: RomAvailability;
+
+  if (!volumeAccessible) {
+    result = { filePathExists: false, volumeDisconnected: true };
+  } else {
+    try {
+      await access(rom.filePath, constants.R_OK);
+      result = { filePathExists: true, volumeDisconnected: false };
+    } catch {
+      result = { filePathExists: false, volumeDisconnected: false };
     }
   }
 
-  try {
-    await access(rom.filePath, constants.R_OK);
-    availabilityCache.set(rom.id, true);
-    return true;
-  } catch {
-    availabilityCache.set(rom.id, false);
-    return false;
-  }
+  availabilityCache.set(rom.id, result);
+  return result;
 }

--- a/src/types/electron-api.ts
+++ b/src/types/electron-api.ts
@@ -125,7 +125,12 @@ export interface SyncFailReason {
 }
 export interface SyncSkipReason {
   rom: Rom;
-  reason: 'unsupported_system' | 'unsupported_format' | 'file_exists' | 'missing_system_mapping';
+  reason:
+    | 'unsupported_system'
+    | 'unsupported_format'
+    | 'file_exists'
+    | 'missing_system_mapping'
+    | 'volume_unreachable';
   details: string;
 }
 

--- a/src/types/rom.ts
+++ b/src/types/rom.ts
@@ -61,6 +61,8 @@ export interface Rom {
   notes?: string | null;
   /** Whether the file path exists on disk (computed at runtime, not stored) */
   filePathExists?: boolean;
+  /** Whether the ROM's volume is disconnected (e.g. external drive not mounted) — file may be fine when reconnected (computed at runtime, not stored) */
+  volumeDisconnected?: boolean;
   /** Number of achievements available in RetroAchievements (computed at runtime, not stored) */
   numAchievements?: number;
 

--- a/src/utils/romFilters.test.ts
+++ b/src/utils/romFilters.test.ts
@@ -118,9 +118,36 @@ describe('romFilters', () => {
       expect(byAvailability('available')(createRom({ filePathExists: false }))).toBe(false);
     });
 
-    it('unavailable matches ROMs with missing files', () => {
-      expect(byAvailability('unavailable')(createRom({ filePathExists: false }))).toBe(true);
-      expect(byAvailability('unavailable')(createRom({ filePathExists: true }))).toBe(false);
+    it('missing matches ROMs with truly missing files', () => {
+      expect(byAvailability('missing')(createRom({ filePathExists: false }))).toBe(true);
+      expect(byAvailability('missing')(createRom({ filePathExists: true }))).toBe(false);
+      expect(
+        byAvailability('missing')(createRom({ filePathExists: false, volumeDisconnected: true }))
+      ).toBe(false);
+    });
+
+    it('disconnected matches ROMs on disconnected drives', () => {
+      expect(byAvailability('disconnected')(createRom({ volumeDisconnected: true }))).toBe(true);
+      expect(byAvailability('disconnected')(createRom({ filePathExists: true }))).toBe(false);
+      expect(byAvailability('disconnected')(createRom({ filePathExists: false }))).toBe(false);
+    });
+
+    it('each filter is mutually exclusive', () => {
+      const available = createRom({ filePathExists: true });
+      const missing = createRom({ filePathExists: false });
+      const disconnected = createRom({ filePathExists: false, volumeDisconnected: true });
+
+      expect(byAvailability('available')(available)).toBe(true);
+      expect(byAvailability('missing')(available)).toBe(false);
+      expect(byAvailability('disconnected')(available)).toBe(false);
+
+      expect(byAvailability('available')(missing)).toBe(false);
+      expect(byAvailability('missing')(missing)).toBe(true);
+      expect(byAvailability('disconnected')(missing)).toBe(false);
+
+      expect(byAvailability('available')(disconnected)).toBe(false);
+      expect(byAvailability('missing')(disconnected)).toBe(false);
+      expect(byAvailability('disconnected')(disconnected)).toBe(true);
     });
   });
 

--- a/src/utils/romFilters.ts
+++ b/src/utils/romFilters.ts
@@ -1,7 +1,7 @@
 import type { Rom } from '@/types/rom';
 
 export type AchievementFilter = 'has-achievements' | 'no-achievements' | 'unverified' | null;
-export type AvailabilityFilter = 'available' | 'unavailable' | null;
+export type AvailabilityFilter = 'available' | 'missing' | 'disconnected' | null;
 
 export const byQuery = (query: string) => (rom: Rom) =>
   !query || rom.displayName.toLowerCase().includes(query.toLowerCase());
@@ -24,8 +24,14 @@ export const byAchievements = (filter: AchievementFilter) => (rom: Rom) => {
   }
 };
 
-export const byAvailability = (filter: AvailabilityFilter) => (rom: Rom) =>
-  !filter || (filter === 'available') === !!rom.filePathExists;
+export const byAvailability = (filter: AvailabilityFilter) => (rom: Rom) => {
+  if (!filter) return true;
+  if (filter === 'disconnected') return !!rom.volumeDisconnected;
+  if (filter === 'available') return !!rom.filePathExists;
+  if (filter === 'missing') return !rom.filePathExists && !rom.volumeDisconnected;
+
+  return false;
+};
 
 export const combineFilters = (...predicates: Array<(rom: Rom) => boolean>) => {
   return (rom: Rom) => predicates.every((p) => p(rom));

--- a/src/views/RomDetailView.vue
+++ b/src/views/RomDetailView.vue
@@ -27,15 +27,27 @@
       </template>
       <template #content>
         <div class="rom-details__content">
-          <Message v-if="!rom.filePathExists" severity="warn" :closable="false">
+          <Message
+            v-if="!rom.filePathExists && !rom.volumeDisconnected"
+            severity="warn"
+            :closable="false"
+          >
             <p class="rom-details__alert-text">
-              The ROM file could not be located. It may have been moved, deleted, or is on a
-              disconnected drive.
+              The ROM file could not be located. It may have been moved or deleted.
             </p>
             <code class="rom-details__alert-path">{{ rom.filePath }}</code>
             <p class="rom-details__alert-hint">
               Use the <strong>Delete</strong> button below to remove this ROM from your library.
             </p>
+          </Message>
+          <Message
+            v-if="rom.volumeDisconnected"
+            size="small"
+            severity="warn"
+            variant="simple"
+            icon="pi pi-ban"
+          >
+            Drive not connected
           </Message>
           <RomAchievements
             :verified="rom.verified"


### PR DESCRIPTION
ROMs on external or network drives no longer show as missing when the drive isn't connected. They stay visible and undimmed in your library, and sync skips them cleanly instead of counting them as failures. A new "Disconnected" filter lets you find them when you need to.

Fixes #142