### PR TITLE
feat: add GameCube support (.iso, .rvz, .gcm)

### DIFF
--- a/src/main/roms/romScan.ts
+++ b/src/main/roms/romScan.ts
@@ -21,6 +21,7 @@ interface ScanResult {
 
 const SUPPORTED_EXTENSIONS = getAllSupportedExtensions();
 const SEVEN_ZIP_PATH = get7zBinaryPath();
+const LARGE_DISC_EXTENSIONS = new Set(['.iso', '.rvz', '.gcm']);
 const log = logger.scope('rom-scan');
 
 export async function processRomDirectory(dirPath: PathLike): Promise<ScanResult> {
@@ -93,8 +94,8 @@ async function processFile(dirPath: PathLike, filename: string): Promise<ScanRes
 
       let fileBuffer: Buffer | undefined;
 
-      // ISO files can be very large, so avoid reading them fully into memory.
-      if (ext !== '.iso') {
+      // Large disc images can be several GB, so avoid reading them fully into memory.
+      if (!LARGE_DISC_EXTENSIONS.has(ext)) {
         fileBuffer = await fs.readFile(fullPath);
       }
 
@@ -244,12 +245,12 @@ async function readRomFromSevenZip(archivePath: string): Promise<RomFile | null>
   const romEntry = romEntries[0];
   const romExt = path.extname(romEntry).toLowerCase();
 
-  // Check for ISO before extraction
-  if (romExt === '.iso') {
+  // Check for large disc images before extraction
+  if (LARGE_DISC_EXTENSIONS.has(romExt)) {
     throw new RomProcessingError(
-      'ISO files in archives are not supported',
+      'Large disc images in archives are not supported',
       archivePath,
-      'Please extract ISO files before importing. They are too large (15-20s extraction time) to efficiently process from archives.'
+      'Please extract disc images before importing. They are too large (15-20s extraction time) to efficiently process from archives.'
     );
   }
 
@@ -350,12 +351,12 @@ async function readRomFromZip(zipPath: string): Promise<RomFile | null> {
           }
           const romExt = path.extname(entry.fileName).toLowerCase();
 
-          if (romExt === '.iso') {
+          if (LARGE_DISC_EXTENSIONS.has(romExt)) {
             reject(
               new RomProcessingError(
-                'ISO files in archives are not supported',
+                'Large disc images in archives are not supported',
                 zipPath,
-                'Please extract ISO files before importing. They are too large (15-20s extraction time) to efficiently process from archives.'
+                'Please extract disc images before importing. They are too large (15-20s extraction time) to efficiently process from archives.'
               )
             );
             return;

--- a/src/main/roms/romUtils.ts
+++ b/src/main/roms/romUtils.ts
@@ -1,6 +1,7 @@
 import { rhash, ConsoleId, type ConsoleIdValue } from 'node-rcheevos';
 import crypto from 'crypto';
 import fs from 'fs/promises';
+import path from 'path';
 import CRC32 from 'crc-32';
 import type { PathLike } from 'fs';
 import type { RomFile, RomRegion } from '../../types/rom';
@@ -136,6 +137,10 @@ export function ramd5sum(consoleId: number | null, romFile: RomFile): string | n
   if (!consoleId) return null;
 
   const { romPath, romBuffer, romFilename, sourcePath } = romFile;
+
+  // rcheevos can't hash .rvz — it's a Dolphin compressed container, not a raw disc image.
+  // It checks for GameCube magic bytes at offset 0x1C and throws on compressed formats.
+  if (path.extname(romFilename).toLowerCase() === '.rvz') return null;
 
   // If we have a buffer then use it unless it's from an arcade game. These files must use
   // path since their hash is based on filename.

--- a/src/packages/device-profiles/src/profiles/retroarch.ts
+++ b/src/packages/device-profiles/src/profiles/retroarch.ts
@@ -49,6 +49,10 @@ export const RETROARCH_PROFILE: DeviceProfile = {
       folderName: 'Nintendo - Nintendo DSi',
       supportedFormats: ['.nds', '.dsi', '.srl', '.zip', '.7z'],
     },
+    gc: {
+      folderName: 'Nintendo GameCube',
+      supportedFormats: ['.iso', '.rvz', '.gcm'],
+    },
     vb: {
       folderName: 'Nintendo - Virtual Boy',
       supportedFormats: ['.vb', '.zip', '.7z'],

--- a/src/types/system.ts
+++ b/src/types/system.ts
@@ -3,6 +3,7 @@ export const SYSTEM_CODES = [
   'snes',
   'vb',
   'n64',
+  'gc',
   'gb',
   'gbc',
   'gba',

--- a/src/utils/system.utils.ts
+++ b/src/utils/system.utils.ts
@@ -7,6 +7,7 @@ const SYSTEM_COLORS: Record<SystemCode, string> = {
   nes: '#364d30', // olive green - distinct Nintendo color
   snes: '#443966', // dusty indigo - classic SNES purple
   n64: '#2563EB', // bright blue - stands out from other Nintendo
+  gc: '#6D28D9', // purple - GameCube's signature color
   vb: '#991B1B', // red - matches Virtual Boy's red display
   gb: '#2c6153', // deep teal - classic Game Boy
   gbc: '#6B46C1', // purple - represents color capability

--- a/src/utils/systems/index.ts
+++ b/src/utils/systems/index.ts
@@ -12,6 +12,7 @@ interface RASystemMapping {
 export const RA_SYSTEMS: RASystemMapping[] = [
   { consoleId: 1, code: 'genesis' }, // MEGA_DRIVE
   { consoleId: 2, code: 'n64' }, // NINTENDO_64
+  { consoleId: 16, code: 'gc' }, // GAMECUBE
   { consoleId: 3, code: 'snes' }, // SUPER_NINTENDO
   { consoleId: 4, code: 'gb' }, // GAMEBOY
   { consoleId: 5, code: 'gba' }, // GAMEBOY_ADVANCE
@@ -61,7 +62,7 @@ export function getSystemInfo(code: SystemCode): SystemInfo {
 }
 
 export function getAllSupportedExtensions(): string[] {
-  return systems.flatMap((system) => system.extensions).sort();
+  return [...new Set(systems.flatMap((system) => system.extensions))].sort();
 }
 
 export function getSystemsByType(type: SystemType): SystemInfo[] {

--- a/src/utils/systems/systemRegistry.ts
+++ b/src/utils/systems/systemRegistry.ts
@@ -36,6 +36,17 @@ export const SYSTEM_REGISTRY: Partial<Record<SystemCode, SystemInfo>> = {
     manufacturer: 'Nintendo',
     releaseYear: 1996,
   },
+  gc: {
+    code: 'gc',
+    displayName: 'GameCube',
+    fullName: 'Nintendo GameCube',
+    type: 'console',
+    extensions: ['.iso', '.rvz', '.gcm'],
+    aliases: ['gamecube', 'gc', 'nintendo gamecube'],
+    requiresBios: false,
+    manufacturer: 'Nintendo',
+    releaseYear: 2001,
+  },
   vb: {
     code: 'vb',
     displayName: 'Virtual Boy',


### PR DESCRIPTION
GameCube ROMs now import correctly. .rvz files (Dolphin's compressed format) import successfully but won't work with the RetroAchievements integration since rcheevos can't hash this format.

Closes #145