### PR TITLE
Add MSX2 to supported systems

### DIFF
--- a/docs/reference/supported-systems.md
+++ b/docs/reference/supported-systems.md
@@ -21,7 +21,7 @@ These are the systems ROMie can identify and organize. Whether a system can be s
 | Neo Geo Pocket            | `.ngp`, `.ngc`, `.zip`, `.7z`                                 |
 | Virtual Boy               | `.vb`, `.zip`, `.7z`                                          |
 | PC Engine                 | `.pce`, `.zip`, `.7z`                                         |
-| MSX                       | `.dsk`, `.mx1`, `.mx2`, `.rom`, `.cas`, `.m3u`, `.zip`, `.7z` |
+| MSX / MSX2                | `.dsk`, `.mx1`, `.mx2`, `.rom`, `.cas`, `.m3u`, `.zip`, `.7z` |
 | WonderSwan                | `.ws`, `.wsc`, `.zip`, `.7z`                                  |
 | Arcade                    | `.zip`, `.7z`                                                 |
 


### PR DESCRIPTION
## What's changed?
Updated supported systems list from the docs.
## Why?
Because the MSX support was added with MSX2 too.
