### PR TITLE
Update installation instructions for Linux

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,7 +6,8 @@ ROMie runs on macOS, Windows and Linux. Download the latest release from the [Gi
 
 **Windows**: download the `.exe` installer and run it.
 
-**Linux** ([Flatpak coming soon](https://github.com/jzimz/romie/issues/41)): 
+**Linux** ([Flatpak coming soon](https://github.com/jzimz/romie/issues/41)):
+
 - **Any distribution**: download the `.appimage` installer and run it.
 - **Fedora / Arch based**: download the `.rpm` installer and run it.
 - **Debian / Ubuntu based**: download the `.deb` installer and run it.


### PR DESCRIPTION
## What's changed?
Added Linux installation instructions in the documentation.

## Why?
Because there are installers for linux put but
 it didn't say in the docs.