### PR TITLE
fix: skip ROMs with missing filePath during LowDB migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ src/
 - Use Vue 3 Composition API with `<script setup lang="ts">`
 - Use `defineProps` and `defineEmits` for component props and events
 - Prefer PrimeVue components over custom UI implementations
+- Prefer early `continue`/`return` with a counter over building intermediate filtered arrays
 
 ### Styling
 

--- a/src/main/db/migrations/migrate-from-lowdb.ts
+++ b/src/main/db/migrations/migrate-from-lowdb.ts
@@ -56,8 +56,16 @@ function migrateRoms(db: AppDatabase, data: RomDatabase['roms']) {
   }
 
   log.info(`Migrating ${data.length} ROMs...`);
+  let skipped = 0;
 
   for (const rom of data) {
+    // Very old installs may still exist without a filePath on ROMs. This was a breaking change
+    // introduced by `51370be` so if we run into any of these they should be skipped.
+    if (!rom.filePath) {
+      skipped++;
+      continue;
+    }
+
     db.insert(schema.roms)
       .values({
         id: rom.id,
@@ -83,7 +91,10 @@ function migrateRoms(db: AppDatabase, data: RomDatabase['roms']) {
       .run();
   }
 
-  log.info(`Successfully migrated ${data.length} ROMs`);
+  log.info(`Successfully migrated ${data.length - skipped} ROMs`);
+  if (skipped > 0) {
+    log.warn(`Skipped ${skipped} ROM(s) with missing filePath. These will need to be re-imported.`);
+  }
 }
 
 function migrateDevices(db: AppDatabase, data: RomDatabase['devices']) {


### PR DESCRIPTION
ROMs imported with a pre-directory-scan version of ROMie (DB schema v1.0.0) never had a filePath field. When migrating to SQLite, inserting these with filePath=undefined triggered a NOT NULL constraint failure that crashed the app on startup.

Closes #163