### PR TITLE
Add type annotations to IPC handler parameters

### DIFF
--- a/src/main/ipc/device.ts
+++ b/src/main/ipc/device.ts
@@ -9,14 +9,15 @@ import {
 
 import { listDeviceProfiles, addDevice } from '@main/roms/romDatabase';
 import { devices } from '@main/db/queries';
+import type { Device } from '@/types/device';
 
 export function registerDeviceIpc() {
   ipcMain.handle('device:list', () => devices.list());
   ipcMain.handle('device:listStorage', listStorage);
   ipcMain.handle('device:listProfiles', listDeviceProfiles);
-  ipcMain.handle('device:create', (_, data) => addDevice(data));
-  ipcMain.handle('device:remove', (_, id) => removeDevice(id));
-  ipcMain.handle('device:update', (_, id, data) => updateDevice(id, data));
-  ipcMain.handle('device:checkDeviceMount', (_, deviceId) => checkDeviceMount(deviceId));
+  ipcMain.handle('device:create', (_, data: Device) => addDevice(data));
+  ipcMain.handle('device:remove', (_, id: string) => removeDevice(id));
+  ipcMain.handle('device:update', (_, id: string, data: Partial<Device>) => updateDevice(id, data));
+  ipcMain.handle('device:checkDeviceMount', (_, deviceId: string) => checkDeviceMount(deviceId));
   ipcMain.handle('device:uploadProfile', uploadProfile);
 }

--- a/src/main/ipc/sync.ts
+++ b/src/main/ipc/sync.ts
@@ -19,7 +19,7 @@ let syncCancelled = false;
 
 //=== PUBLIC API ===
 export function registerSyncIpc() {
-  ipcMain.handle('sync:start', (_, tagIds, deviceId, options) =>
+  ipcMain.handle('sync:start', (_, tagIds: string[], deviceId: string, options: SyncOptions) =>
     startSync(tagIds, deviceId, options)
   );
   ipcMain.handle('sync:cancel', cancelSync);


### PR DESCRIPTION
## Summary

IPC handler callbacks in `src/main/ipc/device.ts` and `src/main/ipc/sync.ts` were accepting parameters typed as implicit `any`. Since IPC is an important trust boundary between Electron's renderer and main processes, having untyped parameters means TypeScript can't catch bugs where the wrong data is passed or the shape of arguments changes.

- In `sync.ts`, the `sync:start` handler now declares `tagIds: string[]`, `deviceId: string`, and `options: SyncOptions` — types that were already imported in the file but not applied to the handler callback.
- In `device.ts`, the four handlers that forward arguments to service functions now declare their parameters using the `Device` type (already used throughout the service layer), making the handler signatures self-documenting and compiler-checked.

This makes the IPC layer consistent: other handlers in the codebase (e.g. `settings.ts`) already annotate their parameters, so these two files were the odd ones out.

## What's better

- **Type safety at the IPC boundary**: mismatches between what the renderer sends and what the main process expects will now be caught at compile time rather than at runtime.
- **Readability**: the handler signatures now document their contracts without needing to trace through to the underlying service functions.

https://claude.ai/code/session_017mYtaignsX8oCKT17X1fJS