### PR TITLE
refactor: eliminate redundant DB query in romsQueries.update()

### DIFF
--- a/src/main/db/queries/roms.ts
+++ b/src/main/db/queries/roms.ts
@@ -25,13 +25,15 @@ export const romsQueries = {
   },
 
   update(id: string, updates: Partial<Omit<Rom, 'id' | 'createdAt' | 'updatedAt'>>) {
-    db.update(schema.roms)
+    return db
+      .update(schema.roms)
       .set({
         ...updates,
         updatedAt: new Date(),
       })
       .where(eq(schema.roms.id, id))
-      .run();
+      .returning()
+      .get();
   },
 
   remove(ids: string | string[]) {

--- a/src/main/roms/romDatabase.ts
+++ b/src/main/roms/romDatabase.ts
@@ -32,7 +32,7 @@ export async function addRom(rom: RomDraft): Promise<Rom> {
 
     if (existing.filePath !== rom.filePath && !originalExists && !volumeDisconnected) {
       // Original file no longer accessible - update the record with new path
-      roms.update(existing.id, {
+      const updated = roms.update(existing.id, {
         filePath: rom.filePath,
         filename: rom.filename,
         romFilename: rom.romFilename,
@@ -43,9 +43,9 @@ export async function addRom(rom: RomDraft): Promise<Rom> {
         region: rom.region,
         system: rom.system,
       });
-      const updated = roms.findById(existing.id)!;
       await validateRomExists(updated, true);
       log.info(`ROM path updated: ${existing.filename} -> ${rom.filename}`);
+
       return updated;
     }
     // Either same path or original still exists - reject as duplicate


### PR DESCRIPTION
## What

`romsQueries.update()` was calling `.run()` and discarding the result, which meant the caller (`addRom`) had to immediately follow up with a `findById` query to retrieve the updated record — two DB round-trips for what should be one operation.

This PR switches `update()` to use `.returning().get()`, matching the pattern already used by `insert()`, and updates the one call site to use the returned record directly.

## Why it's better

- **One DB round-trip instead of two** — `addRom()` no longer needs a separate `findById` after updating a relocated ROM's path.
- **Consistent API** — `insert()` already returns the inserted record; `update()` now does the same, making the query layer predictable.
- **Better type information** — callers can now inspect the updated record or check for `undefined` (no match) without an extra query.

## Changes

- `src/main/db/queries/roms.ts` — `update()` now returns the updated row via `.returning().get()`
- `src/main/roms/romDatabase.ts` — `addRom()` uses the returned value directly, removing the now-redundant `roms.findById()` call