### PR TITLE
Constrain settings update keys to valid AppSettings properties

### DIFF
--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -28,7 +28,7 @@ function getUiSettings() {
 export function registerSettingsIpc() {
   ipcMain.handle('settings:get', getUiSettings);
   ipcMain.handle('settings:update', (_, update: Partial<AppSettings>) => {
-    const next: Record<string, string> = {};
+    const next: Partial<Record<keyof AppSettings, string>> = {};
     if (update.theme) next.theme = update.theme;
     if (update.systemOrder) next.systemOrder = JSON.stringify(update.systemOrder);
     settings.setMany(next);


### PR DESCRIPTION
## Summary

In `src/main/ipc/settings.ts`, the `settings:update` IPC handler was building an intermediate update object typed as `Record<string, string>` — allowing any arbitrary string as a key. This meant a typo like `next.theem = ...` or an invalid key like `next.windowState = ...` would silently pass through the type checker with no error.

**Before:**
```ts
const next: Record<string, string> = {};
```

**After:**
```ts
const next: Partial<Record<keyof AppSettings, string>> = {};
```

## Why this is better

- TypeScript will now catch invalid or misspelled keys at compile time rather than silently passing garbage to the database layer.
- The type accurately documents intent: we're building a partial update of serialized `AppSettings` values.
- If a new field is added to `AppSettings` and someone tries to include it here with a typo, they'll get an immediate compiler error instead of a runtime bug.

https://claude.ai/code/session_01YB4b21F8oTwt5eAUHud7Vn