### PR TITLE
Simplify toggleId to use filter instead of slice

### DIFF
--- a/src/components/RomList.vue
+++ b/src/components/RomList.vue
@@ -57,14 +57,7 @@ onMounted(() => {
 });
 
 function toggleId(selections: string[], id: string): string[] {
-  const idx = selections.indexOf(id);
-  if (idx !== -1) {
-    // Remove selection
-    return [...selections.slice(0, idx), ...selections.slice(idx + 1)];
-  } else {
-    // Add
-    return [...selections, id];
-  }
+  return selections.includes(id) ? selections.filter((sid) => sid !== id) : [...selections, id];
 }
 
 function computeRangeSelection(selections: string[], roms: Rom[], clickedId: string): string[] {


### PR DESCRIPTION
The `toggleId` function in `RomList.vue` was removing items from the selection array by reconstructing it with two `slice` calls, which allocates three arrays per deselection. This pattern also needed inline comments to explain what was happening, which is a sign the code wasn't self-describing.

**Before:**
```ts
function toggleId(selections: string[], id: string): string[] {
  const idx = selections.indexOf(id);
  if (idx !== -1) {
    // Remove selection
    return [...selections.slice(0, idx), ...selections.slice(idx + 1)];
  } else {
    // Add
    return [...selections, id];
  }
}
```

**After:**
```ts
function toggleId(selections: string[], id: string): string[] {
  return selections.includes(id)
    ? selections.filter((sid) => sid !== id)
    : [...selections, id];
}
```

**Why it's better:**
- **Fewer allocations:** `filter` does a single pass and creates one array instead of two intermediate slices plus a spread.
- **More readable:** `includes` + `filter` directly expresses intent — "if it's in there, remove it; otherwise add it" — without needing comments.
- **Less code:** 5 lines → 3 lines with no loss of clarity.

The behaviour is identical; this is a pure readability and minor performance improvement.

https://claude.ai/code/session_01XFx8U5RA5zMsnNwKB9inMZ