### PR TITLE
Make ROM details pane responsive using clamp() for width

### DIFF
--- a/src/layouts/RomListLayout.vue
+++ b/src/layouts/RomListLayout.vue
@@ -109,7 +109,7 @@
           :loading="romStore.loading"
         ></slot>
       </div>
-      <div class="rom-list-layout__content-detail">
+      <div v-if="$slots['rom-details']" class="rom-list-layout__content-detail">
         <slot name="rom-details"></slot>
       </div>
     </div>
@@ -326,6 +326,12 @@ function getUniqueRomValues<T extends keyof Rom>(field: T) {
 
     &-list {
       flex: 1;
+      min-width: 0;
+    }
+
+    &-detail {
+      width: clamp(320px, 28%, 520px);
+      flex-shrink: 0;
     }
   }
 

--- a/src/views/FavoritesView.vue
+++ b/src/views/FavoritesView.vue
@@ -18,18 +18,14 @@
         />
       </div>
     </template>
-    <template #rom-details>
+    <template v-if="romSelections.length > 0" #rom-details>
       <RomDetailView
         v-if="romSelections.length === 1"
         :rom-id="romSelections[0]"
         @favorite="handleFavorite"
         @delete="romSelections = []"
       />
-      <RomActionView
-        v-else-if="romSelections.length > 1"
-        :rom-selections="romSelections"
-        @delete="romSelections = []"
-      />
+      <RomActionView v-else :rom-selections="romSelections" @delete="romSelections = []" />
     </template>
   </RomListLayout>
 </template>

--- a/src/views/LibraryView.vue
+++ b/src/views/LibraryView.vue
@@ -13,17 +13,13 @@
         />
       </div>
     </template>
-    <template #rom-details>
+    <template v-if="romSelections.length > 0" #rom-details>
       <RomDetailView
         v-if="romSelections.length === 1"
         :rom-id="romSelections[0]"
         @delete="romSelections = []"
       />
-      <RomActionView
-        v-else-if="romSelections.length > 1"
-        :rom-selections="romSelections"
-        @delete="romSelections = []"
-      />
+      <RomActionView v-else :rom-selections="romSelections" @delete="romSelections = []" />
     </template>
   </RomListLayout>
 </template>

--- a/src/views/RomActionView.vue
+++ b/src/views/RomActionView.vue
@@ -145,7 +145,7 @@ async function handleTagUpdate(newTags: string[]) {
 
 <style scoped lang="less">
 .rom-bulk-actions {
-  width: 350px;
+  width: 100%;
   height: 100%;
   padding: 16px;
 

--- a/src/views/RomDetailView.vue
+++ b/src/views/RomDetailView.vue
@@ -314,7 +314,7 @@ function formatDatetime(ts: number): string {
 
 <style scoped lang="less">
 .rom-details {
-  width: 350px;
+  width: 100%;
   height: 100%;
   padding: 12px;
 

--- a/src/views/SystemView.vue
+++ b/src/views/SystemView.vue
@@ -18,17 +18,13 @@
         />
       </div>
     </template>
-    <template #rom-details>
+    <template v-if="romSelections.length > 0" #rom-details>
       <RomDetailView
         v-if="romSelections.length === 1"
         :rom-id="romSelections[0]"
         @delete="romSelections = []"
       />
-      <RomActionView
-        v-else-if="romSelections.length > 1"
-        :rom-selections="romSelections"
-        @delete="romSelections = []"
-      />
+      <RomActionView v-else :rom-selections="romSelections" @delete="romSelections = []" />
     </template>
   </RomListLayout>
 </template>

--- a/src/views/TagView.vue
+++ b/src/views/TagView.vue
@@ -18,17 +18,13 @@
         />
       </div>
     </template>
-    <template #rom-details>
+    <template v-if="romSelections.length > 0" #rom-details>
       <RomDetailView
         v-if="romSelections.length === 1"
         :rom-id="romSelections[0]"
         @delete="romSelections = []"
       />
-      <RomActionView
-        v-else-if="romSelections.length > 1"
-        :rom-selections="romSelections"
-        @delete="romSelections = []"
-      />
+      <RomActionView v-else :rom-selections="romSelections" @delete="romSelections = []" />
     </template>
   </RomListLayout>
 </template>


### PR DESCRIPTION
Replace the fixed 350px width on the details pane with a fluid
clamp(320px, 28%, 520px) on the layout container, so the pane
scales proportionally at larger resolutions while staying readable
at smaller ones.

https://claude.ai/code/session_01AF9xLSxoKpbxyrM4CCNtrx