### PR TITLE
refactor: improve variable names in formatBytes

### DIFF
--- a/src/utils/number.utils.ts
+++ b/src/utils/number.utils.ts
@@ -1,10 +1,14 @@
 export function formatBytes(bytes: number, decimals = 1): string {
   if (bytes === 0) return '0 Bytes';
-  const k = 1024;
-  const dm = decimals < 0 ? 0 : decimals;
+  const bytesPerUnit = 1024;
+  const precision = decimals < 0 ? 0 : decimals;
   const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+  const unitIndex = Math.floor(Math.log(bytes) / Math.log(bytesPerUnit));
+  return (
+    parseFloat((bytes / Math.pow(bytesPerUnit, unitIndex)).toFixed(precision)) +
+    ' ' +
+    sizes[unitIndex]
+  );
 }
 
 /**


### PR DESCRIPTION
The `formatBytes` utility used single-letter variable names (`k`, `dm`, `i`) that required a mental lookup to understand. A reader had to trace each variable back to its definition to know what the formula was doing.

This replaces them with descriptive names that match the style already used in the adjacent `formatCompactNumber` function:

- `k` → `bytesPerUnit`
- `dm` → `precision`
- `i` → `unitIndex`

The logic is identical — this is a pure readability change with no behaviour difference.

https://claude.ai/code/session_01NNfAxhN732HLnQbiyejEwt