### PR TITLE
refactor: convert rom IPC handler from JS to TypeScript

### DIFF
--- a/src/main/ipc/rom.ts
+++ b/src/main/ipc/rom.ts
@@ -2,12 +2,15 @@ import { ipcMain } from 'electron';
 import { scanRomDirectory } from '@main/roms/romService';
 import { listRoms, removeRomById, getRomStats, updateRom } from '@main/roms/romDatabase';
 import { checkRomAvailability } from '@main/roms/romValidation';
+import type { Rom } from '@/types/rom';
 
 export function registerRomIpc() {
   ipcMain.handle('rom:scan', scanRomDirectory);
   ipcMain.handle('rom:list', listRoms);
-  ipcMain.handle('rom:remove', (_, id, deleteFile) => removeRomById(id, deleteFile === true));
-  ipcMain.handle('rom:update', (_, id, data) => updateRom(id, data));
+  ipcMain.handle('rom:remove', (_, id: string, deleteFile: boolean) =>
+    removeRomById(id, deleteFile === true)
+  );
+  ipcMain.handle('rom:update', (_, id: string, data: Partial<Rom>) => updateRom(id, data));
   ipcMain.handle('rom:stats', () => getRomStats());
   ipcMain.handle('rom:refresh', checkRomAvailability);
 }


### PR DESCRIPTION
Every other file in `src/main/ipc/` is TypeScript — `device.ts`, `settings.ts`, `database.ts`, `diagnostics.ts`, `sync.ts` — except `rom.js`. Because `checkJs: false` is set in `tsconfig.json`, the JavaScript file gets no compile-time type checking at all.

## What changed

Renamed `rom.js` → `rom.ts` and added explicit type annotations to the two inline IPC handlers:

```ts
// before (no type checking)
ipcMain.handle('rom:remove', (_, id, deleteFile) => removeRomById(id, deleteFile === true));
ipcMain.handle('rom:update', (_, id, data) => updateRom(id, data));

// after (compiler validates the arguments)
ipcMain.handle('rom:remove', (_, id: string, deleteFile: boolean) => removeRomById(id, deleteFile === true));
ipcMain.handle('rom:update', (_, id: string, data: Partial<Rom>) => updateRom(id, data));
```

## Why it's better

- `removeRomById` expects `string | string[]` for `id` and `updateRom` expects `string` — TypeScript now enforces this at the IPC boundary so a future refactor that changes these signatures will surface a compile error immediately rather than silently passing mismatched values at runtime.
- Brings `rom.ts` in line with every other IPC file in the directory, making the codebase consistent.
- No behaviour change — the runtime logic is identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_0171zVwL4PkuPBm8XW1gfG4Q)_