### PR TITLE
feat: add the ability to delete devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -300,6 +300,7 @@
       "integrity": "sha512-0XLrOT4Cm3NEhhiME7l/8LbTXS4KdsbR4dSrY207KNKTcHLLTZ9EXt4ZpgnTfLvWQF3pGP2us4Zi1fYLo0N+Ow==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1849,6 +1850,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -2239,29 +2241,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3670,6 +3649,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -3946,6 +3926,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3967,6 +3948,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
       "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4372,6 +4354,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -4389,6 +4372,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6475,6 +6459,7 @@
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6652,6 +6637,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6772,6 +6758,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -7681,6 +7668,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7766,6 +7754,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7979,6 +7968,7 @@
       "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -8090,6 +8080,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8687,6 +8678,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -10255,31 +10247,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -10488,6 +10455,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11180,6 +11148,7 @@
       "integrity": "sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.4.0"
       }
@@ -12465,6 +12434,7 @@
       "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -12515,6 +12485,7 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -14870,6 +14841,7 @@
       "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
       "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^7.7.7"
       },
@@ -16898,6 +16870,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17361,6 +17334,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -17694,6 +17668,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
       "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.33",
         "@vue/compiler-sfc": "3.5.33",
@@ -17716,7 +17691,6 @@
       "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -17741,7 +17715,6 @@
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },

--- a/src/main/devices/deviceService.ts
+++ b/src/main/devices/deviceService.ts
@@ -59,7 +59,8 @@ export async function createDevice(data: Device): Promise<Device> {
 }
 
 export async function removeDevice(id: string): Promise<void> {
-  log.warn('deviceService.removeDevice() is not implemented', id);
+  // eslint-disable-next-line drizzle/enforce-delete-with-where
+  devices.delete(id);
 }
 
 export async function updateDevice(id: string, data: Partial<Device>): Promise<void> {

--- a/src/stores/devices.ts
+++ b/src/stores/devices.ts
@@ -60,9 +60,14 @@ export const useDeviceStore = defineStore('devices', {
       }
     },
     async removeDevice(id: string) {
-      await window.device.remove(id);
-      const index = this.devices.findIndex((d) => d.id === id);
-      if (index !== -1) this.devices.splice(index, 1);
+      try {
+        await window.device.remove(id);
+        const index = this.devices.findIndex((d) => d.id === id);
+        if (index !== -1) this.devices.splice(index, 1);
+      } catch (error) {
+        log.error('Failed to remove device:', error);
+        throw error;
+      }
     },
   },
 });

--- a/src/stores/devices.ts
+++ b/src/stores/devices.ts
@@ -59,5 +59,10 @@ export const useDeviceStore = defineStore('devices', {
         this.loading = false;
       }
     },
+    async removeDevice(id: string) {
+      await window.device.remove(id);
+      const index = this.devices.findIndex((d) => d.id === id);
+      if (index !== -1) this.devices.splice(index, 1);
+    },
   },
 });

--- a/src/views/DeviceView.vue
+++ b/src/views/DeviceView.vue
@@ -56,6 +56,17 @@
               <span class="device-status__value">{{ deviceStatus?.freeSpace }}</span>
             </div>
           </div>
+          <div class="device-view__delete-row">
+            <Button
+              label="Delete device"
+              icon="pi pi-trash"
+              severity="danger"
+              text
+              size="small"
+              :disabled="syncStatus.phase !== 'idle'"
+              @click="handleDeleteDevice"
+            />
+          </div>
         </template>
       </Card>
 
@@ -186,6 +197,8 @@ import MultiSelect from 'primevue/multiselect';
 import Popover from 'primevue/popover';
 import Checkbox from 'primevue/checkbox';
 import Button from 'primevue/button';
+import { useConfirm } from 'primevue/useconfirm';
+import { useRouter } from 'vue-router';
 import { useDeviceStore, useRomStore } from '@/stores';
 import { useSyncLogic } from '@/composables/useSyncLogic';
 import SyncProgress from '@/components/device/SyncProgress.vue';
@@ -204,6 +217,8 @@ const props = defineProps<{
 }>();
 
 const op = ref();
+const confirm = useConfirm();
+const router = useRouter();
 const deviceStore = useDeviceStore();
 const romStore = useRomStore();
 const device = ref<Device | null>(null);
@@ -300,6 +315,21 @@ async function startSync() {
 function unselectTag(tagId: string) {
   selectedTags.value = selectedTags.value.filter(({ tag }) => tag !== tagId);
 }
+
+function handleDeleteDevice() {
+  confirm.require({
+    message: `Delete "${device.value?.name}"? This will remove it from ROMie. Your SD card files won't be affected.`,
+    header: 'Delete Device',
+    icon: 'pi pi-exclamation-triangle',
+    rejectLabel: 'Cancel',
+    acceptLabel: 'Delete',
+    acceptProps: { severity: 'danger' },
+    accept: async () => {
+      await deviceStore.removeDevice(props.deviceId);
+      router.push({ name: 'library' });
+    },
+  });
+}
 </script>
 
 <style lang="less" scoped>
@@ -319,6 +349,13 @@ function unselectTag(tagId: string) {
   }
   &__profile {
     cursor: pointer;
+  }
+  &__delete-row {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--p-content-border-color);
   }
 }
 

--- a/src/views/DeviceView.vue
+++ b/src/views/DeviceView.vue
@@ -63,7 +63,7 @@
               severity="danger"
               text
               size="small"
-              :disabled="syncStatus.phase !== 'idle'"
+              :disabled="['preparing', 'copying', 'verifying'].includes(syncStatus.phase)"
               @click="handleDeleteDevice"
             />
           </div>
@@ -198,6 +198,7 @@ import Popover from 'primevue/popover';
 import Checkbox from 'primevue/checkbox';
 import Button from 'primevue/button';
 import { useConfirm } from 'primevue/useconfirm';
+import { useToast } from 'primevue/usetoast';
 import { useRouter } from 'vue-router';
 import { useDeviceStore, useRomStore } from '@/stores';
 import { useSyncLogic } from '@/composables/useSyncLogic';
@@ -218,6 +219,7 @@ const props = defineProps<{
 
 const op = ref();
 const confirm = useConfirm();
+const toast = useToast();
 const router = useRouter();
 const deviceStore = useDeviceStore();
 const romStore = useRomStore();
@@ -325,8 +327,12 @@ function handleDeleteDevice() {
     acceptLabel: 'Delete',
     acceptProps: { severity: 'danger' },
     accept: async () => {
-      await deviceStore.removeDevice(props.deviceId);
-      router.push({ name: 'library' });
+      try {
+        await deviceStore.removeDevice(props.deviceId);
+        router.push({ name: 'library' });
+      } catch {
+        toast.add({ severity: 'error', summary: 'Failed to delete device', life: 4000 });
+      }
     },
   });
 }


### PR DESCRIPTION
## What's changed?

This implements deleting devices from ROMie. 

This was implemented with claude using `superpowers`, and reviewed by a human engineer.

## Why?

In testing this I realized after creating a device that I wanted to reconfigure it with a custom profile, but wasn't able to delete it.

## How to test

1. Add a new device
2. Observe the 'delete device' option on the device detail page
3. Click 'delete device'
4. Cancel the operation with the cancel button, see that you're returned to the device detail page
5. Use 'delete device' again
6. Delete the device, see that you're sent to the Library page and the device is missing. 


<img width="727" height="337" alt="image" src="https://github.com/user-attachments/assets/68c45ff9-2ee3-4cd0-8685-0086c8def39a" />

<img width="471" height="237" alt="image" src="https://github.com/user-attachments/assets/60e8aebb-d433-475c-ad3f-a9054901e0c5" />




